### PR TITLE
Cvx/bug/1

### DIFF
--- a/matlab/cvx_ecos.m
+++ b/matlab/cvx_ecos.m
@@ -119,7 +119,7 @@ if m1 == 1,
 end
 dims = K;
 
-ecos_c = -full(b); % PHLI: Empirically this was needed to match SeDuMi output
+ecos_c = -full(b); % PHLI: Empirically this needed to be negated to match SeDuMi output
 ecos_G = At((K.f+1):end,:);
 ecos_h = full(c((K.f+1):end));
 ecos_A = At(1:K.f,:);


### PR DESCRIPTION
Hey guys, the previous commit on cvx_ecos.m is a bit buggy.  The rearrangement of output variables to reflect dualism seems right, but the negative on full(b) needed to be restored to get output to match SeDuMi.

I wasn't sure whether the variable names passed to cvx_run_solver should match the variable names for ECOS or the undualized version coming back to Matlab; I went with ECOS.  In any case, a fix is needed for the variable names as there weren't enough names included in previous version.
