### PR TITLE
Revert mistakenly added change to py2 init function.

### DIFF
--- a/python/ecosmodule.c
+++ b/python/ecosmodule.c
@@ -610,7 +610,7 @@ static PyObject* moduleinit(void)
     return moduleinit();
   }
 #else
-  PyMODINIT_FUNC init__ecos(void)
+  PyMODINIT_FUNC init_ecos(void)
   {
     import_array(); // for numpy arrays
     moduleinit();


### PR DESCRIPTION
Apologies for the last PR, I mistakenly changed the py2 init function along with the py3 version, the py2 version was correct before.
