### PR TITLE
cvx_solver_shim.m: extract the version number from a test ECOS run

### DIFF
--- a/matlab/cvx_solver_shim.m
+++ b/matlab/cvx_solver_shim.m
@@ -1,4 +1,4 @@
-function shim = cvx_ecos( shim )
+function shim = cvx_ecos( shim ) %#ok
 
 if ~isempty( shim.solve ),
     return
@@ -21,10 +21,18 @@ if isempty( shim.name ),
             continue
         end
         new_dir = fpath(1:end-flen-1);
-        cd( new_dir );
         tshim = oshim;
         tshim.fullpath = fpath;
         tshim.version = 'unknown';
+        if ~exist('OCTAVE_VERSION','builtin'),
+            cd( new_dir );
+            outp = evalc('ecos','[]'); %#ok
+            [tok,remain] = strtok(outp,' ' ); %#ok
+            tok = strtok(remain,' ' );
+            if ~isempty(tok),
+                tshim.version = tok;
+            end
+        end
         tshim.location = new_dir;
         if isempty( tshim.error ),
             tshim.check = @check;


### PR DESCRIPTION
Here you go. Now that ECOS prints out the version number, I've added code to extract it during cvx_setup. 

As an alternative, I could just read the number right out of ../include/ecos.h, I suppose. I do something like that for SeDuMi. This might actually be better anyway, since Octave can't handle evalc. (Not that you're supporting octave yet.)
