### PR TITLE
Windows compatibility and ANSI C comments in Python module.

### DIFF
--- a/python/ecosmodule.c
+++ b/python/ecosmodule.c
@@ -3,7 +3,7 @@
 #include "numpy/arrayobject.h"
 
 /*
- * Macro for MSVC compatibility.
+ * Define INLINE for MSVC compatibility.
  */
 #ifdef _MSC_VER
   #define INLINE __inline


### PR DESCRIPTION
I added a check for MSVC that will redefine "inline". If you have Windows VS, please check that it works.

I also changed all the comments in the module to use ANSI C style comments (just in case).
