### PR TITLE
Update ECOS.jl information

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Features of ECOS
 your embedded hardware.  
 + *ECOS comes with a Python interface*. This interface is built on top of
   [NUMPY](http://numpy.org) and [SCIPY](http://scipy.org/) and uses its sparse data structures.
-+ *There is a Julia interface for ECOS*. [Julia](http://julialang.org) is a high-level, high-performance language for technical and scientific computing. You can pull the Julia interface [here](https://github.com/karanveerm/ecos.jl).
++ *There is a Julia interface for ECOS*. [Julia](http://julialang.org) is a high-level, high-performance language for technical and scientific computing. You can pull the [Julia interface here](https://github.com/JuliaOpt/ECOS.jl).
 + *ECOS is library-free*. No need to link any external library to ECOS, apart from `AMD` and `sparseLDL`, both
   from Timothy A. Davis, which are included in this project.
 
@@ -56,7 +56,7 @@ The following people have been, and are, involved in the development and mainten
 + Stephen Boyd (methods and maths)
 + Michael Grant (CVX interface)
 + Johan Löfberg (YALMIP interface)
-+ Karanveer Mohan (Julia interface)
++ João Felipe Santos, Iain Dunning (Julia inteface)
 
 The main technical idea behind ECOS is described in a short [paper](http://www.stanford.edu/~boyd/papers/ecos.html). More details are given in Alexander Domahidi's [PhD Thesis](http://e-collection.library.ethz.ch/view/eth:7611?q=domahidi) in Chapter 9.
 


### PR DESCRIPTION
@jfsantos

The ECOS interface started by @jfsantos has actually been completed by myself and integrated into the Julia optimization interface. It also has support for automatically downloading and building on Linux and OSX, and we're about to add binary download support for Windows. Hopefully it'll be one of the easiest ways for people to download and try ECOS.

This PR updates the link away from a fork and points to the true, final location, with [appropriate credits](https://github.com/JuliaOpt/ECOS.jl/graphs/contributors)
