### PR TITLE
Updated build process to build a shared library on Linux and OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,10 @@ demo: ldl amd ecos src/runecos.c
 	$(C) -o runecos src/runecos.c libecos.a $(LIBS)
 	echo ECOS successfully built. Type ./runecos to run demo problem.
 
+# Shared library
+shared: ldl amd ecos
+	$(C) -shared -o $(SHAREDNAME) ecos.o kkt.o cone.o preproc.o spla.o splamm.o timer.o equil.o -lldl -lamd -Lexternal/amd/ -Lexternal/ldl/ $(LIBS)
+
 # ECOS tester
 TEST_OBJS = qcml_utils.o norm.o sq_norm.o sum_sq.o quad_over_lin.o inv_pos.o sqrt.o
 test: ldl amd ecos test/ecostester.c $(TEST_OBJS)

--- a/ecos.mk
+++ b/ecos.mk
@@ -7,16 +7,20 @@
 
 ## GNU C Compiler
 #CC = gcc
-CFLAGS = -O2 -Wall -DLDL_LONG -DDLONG -Wextra #-ansi -ipo
+CFLAGS = -O2 -Wall -DLDL_LONG -DDLONG -Wextra -fPIC #-ansi -ipo
 
 UNAME := $(shell uname)
 
 ifeq ($(UNAME), Linux)
 # we're on a linux system, use accurate timer provided by clock_gettime()
 LIBS = -lm -lrt
+# shared library has extension .so
+SHAREDNAME = libecos.so
 else
 # we're on apple, no need to link rt library
 LIBS = -lm
+# shared library has extension .dylib
+SHAREDNAME = libecos.dylib
 endif
 
 
@@ -27,4 +31,4 @@ ARCHIVE = $(AR) $(ARFLAGS)
 RANLIB = ranlib
 
 ## WHICH FILES TO CLEAN UP
-CLEAN = *.o *.obj *.ln *.bb *.bbg *.da *.tcov *.gcov gmon.out *.bak *.d *.gcda *.gcno ecos_bb_test
+CLEAN = *.o *.obj *.ln *.bb *.bbg *.da *.tcov *.gcov gmon.out *.bak *.d *.gcda *.gcno libecos.a libecos.so libecos.dylib ecos_bb_test


### PR DESCRIPTION
@IainNZ @mlubin

In order to call ECOS from the Julia wrapper in [ECOS.jl](https://github.com/JuliaOpt/ECOS.jl), we updated the build process to build it as a shared library. Currently we do it by patching the original files, but we think this could be useful for other users so it may be interesting to have the functionality upstream.

This PR adds a new task to the Makefile (`make shared`), and adds the flag -fPIC to CFLAGS (in order to make the compiled code suitable for dynamic linking). We have also added the generated files to the list of files to be removed on `make clean`.
