### PR TITLE
Fixed norm of the iterative refinement residual

### DIFF
--- a/src/kkt.c
+++ b/src/kkt.c
@@ -186,7 +186,7 @@ idxint kkt_solve(kkt* KKT, spmat* A, spmat* G, pfloat* Pb, pfloat* dx, pfloat* d
         
         /* maximum error (infinity norm of e) */
         nerr = MAX( nex, nez);
-        if( p > 0 ){ nerr = MAX( nerr, nez ); }
+        if( p > 0 ){ nerr = MAX( nerr, ney ); }
         
         /* CHECK WHETHER REFINEMENT BROUGHT DECREASE - if not undo and quit! */
         if( kItRef > 0 && nerr > nerr_prev ){


### PR DESCRIPTION
The iterative refinement code in kkt.c ignored the norm of ey when 
calculating ||ex;ey;ez||_inf. 
