### PR TITLE
Use lowercase <windows.h> for cross-compiling from Linux

### DIFF
--- a/include/ctrlc.h
+++ b/include/ctrlc.h
@@ -39,7 +39,7 @@ extern bool utSetInterruptEnabled(bool);
 #elif (defined _WIN32 || defined _WIN64 || defined _WINDLL )
 
 /* Use Windows SetConsoleCtrlHandler for signal handling */
-#include <Windows.h>
+#include <windows.h>
 
 #else
 

--- a/include/timer.h
+++ b/include/timer.h
@@ -30,7 +30,7 @@
 #if (defined _WIN32 || defined _WIN64 || defined _WINDLL )
 
 /* Use Windows QueryPerformanceCounter for timing */
-#include <Windows.h>
+#include <windows.h>
 
 typedef struct timer{
 	LARGE_INTEGER tic;


### PR DESCRIPTION
This helps with cross-compiling. Need to manually fiddle with the makefiles a bit (to get rid of `-lrt`, and output a `.dll` instead of a `.so`), but otherwise the compilation command is the same as I was using from Cygwin here https://github.com/JuliaOpt/ECOS.jl/issues/16#issuecomment-72537761

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/embotech/ecos/113)
<!-- Reviewable:end -->
