### PR TITLE
Fix memory leak with no exponential cones

### DIFF
--- a/src/preproc.c
+++ b/src/preproc.c
@@ -697,7 +697,7 @@ pwork* ECOS_setup(idxint n, idxint m, idxint p, idxint l, idxint ncones, idxint*
 #ifdef EXPCONE
     /* Exponential cones */
     mywork->C->nexc  = nexc;
-    mywork->C->expc  = (expcone *)MALLOC(nexc*sizeof(expcone));
+    mywork->C->expc  = (nexc == 0) ? NULL : (expcone *)MALLOC(nexc*sizeof(expcone));
     mywork->C->fexv  = cidx+l;
 #if PRINTLEVEL > 2
     PRINTTEXT("Memory allocated for exponential cones\n");


### PR DESCRIPTION
When mywork->C->expc is zero, malloc()ed memory is never freed.

Change-Id: I35354cb82ee79a55819dfaf64a12ffd1762252e2

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/embotech/ecos/132)
<!-- Reviewable:end -->
