### PR TITLE
Corrected balancing of rows that correspond to exponential cones

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.3
+current_version = 2.0.4
 files = include/ecos.h
 commit = True
 tag = True

--- a/include/ecos.h
+++ b/include/ecos.h
@@ -35,7 +35,7 @@
 #endif
 
 /* ECOS VERSION NUMBER - FORMAT: X.Y.Z --------------------------------- */
-#define ECOS_VERSION ("2.0.3")
+#define ECOS_VERSION ("2.0.4")
 
 /* DEFAULT SOLVER PARAMETERS AND SETTINGS STRUCT ----------------------- */
 #define MAXIT      (100)          /* maximum number of iterations         */

--- a/src/equil.c
+++ b/src/equil.c
@@ -151,6 +151,19 @@ void use_alternating_norm_equilibration(pwork *w)
       ind += w->C->soc[i].p;
     }
 
+#ifdef EXPCONE
+    for(i = 0; i < w->C->nexc; i++) {
+      sum = 0.0;
+      for(j = 0; j < 3; j++) {
+        sum += w->Gequil[ind + j];
+      }
+      for(j = 0; j < 3; j++) {
+        w->Gequil[ind + j] = sum / 3.0;
+      }
+      ind += 3;
+    }
+#endif
+
     /* get the norm */
     for(i = 0; i < num_A_rows; i++) {
       w->Aequil[i] = fabs(w->Aequil[i]) < 1e-6 ? 1.0 : sqrt(w->Aequil[i]);
@@ -179,7 +192,7 @@ void use_alternating_norm_equilibration(pwork *w)
     if(num_G_rows > 0)
         equilibrate_cols(w->xequil, w->G);
 
-    /* equilibrate the c vector
+    /* the c vector is scaled in the ECOS_solve function
     for(i = 0; i < num_cols; i++) {
         w->c[i] /= w->xequil[i];
     }  */
@@ -258,6 +271,20 @@ void use_ruiz_equilibration(pwork *w)
           }
           ind += w->C->soc[i].p;
         }
+#ifdef EXPCONE
+       /*Do the same for the exponential cones*/
+       for(i = 0; i < w->C->nexc; i++) {
+         total = 0.0;
+         for(j = 0; j < 3; j++) {
+           total += Gtmp[ind + j];
+         }
+         for(j = 0; j < 3; j++) {
+           Gtmp[ind + j] = total;
+         }
+         ind += 3;
+       }
+#endif
+
 
         /* take the sqrt */
         for(i = 0; i < num_cols; i++) {
@@ -293,7 +320,7 @@ void use_ruiz_equilibration(pwork *w)
         }
     }
 
-    /* equilibrate the c vector
+    /* the c vector is scaled in the ECOS_solve function
     for(i = 0; i < num_cols; i++) {
         w->c[i] /= w->xequil[i];
     } */
@@ -351,8 +378,8 @@ void unset_equilibration(pwork *w)
     if(num_G_rows > 0)
         restore(w->Gequil, w->xequil, w->G);
 
-    /* unequilibrate the c vector
-    for(i = 0; i < num_cols; i++) {
+    /* the c vector is unequilibrated in the ECOS_solve function
+        for(i = 0; i < num_cols; i++) {
         w->c[i] *= w->xequil[i];
     }*/
 

--- a/test/ecostester.c
+++ b/test/ecostester.c
@@ -51,6 +51,7 @@
 #include "exponential/random_infeasible.h"
 #include "exponential/random_unbounded.h"
 #include "exponential/num_err.h"
+#include "exponential/log_ax_x.h"
 #endif
 
 int tests_run = 0;
@@ -79,12 +80,13 @@ static char * all_tests() {
 /*    mu_run_test(test_unboundedMaxSqrt); */
     mu_run_test(test_emptyProblem);
     mu_run_test(test_issue98);
-
+ 
     #ifdef EXPCONE
         mu_run_test(test_random_feasible);
         mu_run_test(test_random_infeasible);
         mu_run_test(test_random_unbounded);
         mu_run_test(test_num_err);
+	mu_run_test(test_log_ax_x);
     #endif
     return 0;
 }

--- a/test/exponential/log_ax_x.h
+++ b/test/exponential/log_ax_x.h
@@ -1,0 +1,52 @@
+#include "ecos.h"
+#include "minunit.h"
+
+/* Solves log(ax)-x for a = 0.3*/
+idxint logax_x_n = 2;
+idxint logax_x_m = 3;
+idxint logax_x_p = 0;
+idxint logax_x_l = 0;
+idxint logax_x_ncones = 0;
+idxint logax_x_nexc = 1;
+
+pfloat logax_x_c[2] = {-1.0, 1.0};
+
+idxint logax_x_Gjc[3] = {0,1,2};
+idxint logax_x_Gir[2] = {0, 1};
+pfloat logax_x_Gpr[2] = {-0.3, -1.0};
+
+pfloat logax_x_h[3] = {0.0,0.0,1.0};
+
+static char * test_log_ax_x(){
+pwork *mywork;
+idxint exitflag;
+ 
+/* print test name */
+printf("=================================== log(ax)-x ===================================\n");
+ 
+/* set up data */
+mywork = ECOS_setup(logax_x_n, logax_x_m, logax_x_p, logax_x_l, logax_x_ncones, NULL, logax_x_nexc,
+                    logax_x_Gpr, logax_x_Gjc, logax_x_Gir,
+                    NULL,NULL,NULL,
+                    logax_x_c, logax_x_h, NULL);
+if( mywork != NULL ){
+/*set precision*/
+	mywork->stgs->feastol = 1e-12;
+/* solve */
+exitflag = ECOS_solve(mywork); 
+}
+else exitflag = ECOS_FATAL;
+
+/* Exact solution */
+pfloat true_x = -log(0.3)/0.3;
+pfloat ecos_x = mywork->x[0];
+pfloat abs_err = fabs(true_x-ecos_x);
+
+/* clean up memory */
+ECOS_cleanup(mywork, 0);
+
+mu_assert("log_ax_x: ECOS failed to produce outputflag OPTIMAL", exitflag == ECOS_OPTIMAL );
+mu_assert("log_ax_x: ECOS failed to produce the desired precision", abs_err < 1e-11);
+
+return 0;
+}


### PR DESCRIPTION
This pull request addresses #135, and cvxgrp/cvxpy#208. 
The balancing code was missing the sections that 
ensure that one coefficient is used for all rows of the exponential cone constraints, without this
the unbalanced solution can fall outside the conic constraints. 
The problem from #135 was added as a test.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/embotech/ecos/136)
<!-- Reviewable:end -->
