### PR TITLE
Backtracking errors will only be printed when verbose == true

### DIFF
--- a/src/ecos.c
+++ b/src/ecos.c
@@ -1525,14 +1525,17 @@ idxint ECOS_solve(pwork* w)
         {
 
 #if PRINTLEVEL > 1
-            PRINTTEXT("Combined backtracking failed %i %i %i %i sigma %g\n",\
-            (int)w->info->cb,\
-            (int)w->info->cob,\
-            (int)w->info->pb,\
-            (int)w->info->db,\
-            sigma);
+            if( w->stgs->verbose ){
+	            PRINTTEXT("Combined backtracking failed %i %i %i %i sigma %g\n",\
+	            (int)w->info->cb,\
+	            (int)w->info->cob,\
+	            (int)w->info->pb,\
+	            (int)w->info->db,\
+	            sigma);
 
-            if( w->stgs->verbose ) PRINTTEXT("Combined line search failed, recovering best iterate (%i) and stopping.\n", (int)w->best_info->iter);
+	            PRINTTEXT("Combined line search failed, recovering best iterate (%i) and stopping.\n",\
+	            (int)w->best_info->iter);
+            }
 #endif
             restoreBestIterate( w );
 


### PR DESCRIPTION
Solves #145

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/embotech/ecos/146)
<!-- Reviewable:end -->
