### PR TITLE
fixed condition to branch on infeasible node

### DIFF
--- a/ecos_bb/ecos_bb.c
+++ b/ecos_bb/ecos_bb.c
@@ -275,7 +275,8 @@ static void get_bounds(idxint node_idx, ecos_bb_pwork* prob){
     }
 #endif
 
-    if (ret_code >= 0 ||
+    if (ret_code == ECOS_OPTIMAL ||
+        ret_code == ECOS_OPTIMAL + ECOS_INACC_OFFSET ||
         ret_code == ECOS_MAXIT ||
         ret_code == ECOS_NUMERICS )
     {


### PR DESCRIPTION
The current version of ecos_bb still tries to calculate `split_idx` and `split_val` on an infeasible node.

If the problem is infeasible there is no integer solution possible that is feasible and therefore there should be no branching on this node.

simple example to test:
<img src="https://latex.codecogs.com/gif.latex?%5Cbegin%7Bmatrix%7D%20%5Ctext%7Bmaximize%7D%20%26%2010x_1%20%26&plus;%26%2017x_2%20%5C%5C%20%5Ctext%7Bs.t.%7D%20%26%20x_1%20%26&plus;%26x_2%20%26%5Cleq%2612%5C%5C%20%26%205x_1%20%26&plus;%269x_2%20%26%5Cleq%2690%5C%5C%20%5Cend%7Bmatrix%7D" />

C Code:

	idxint n = 4;
	idxint m = 4;
	idxint p = 2;
	idxint l = 4;
	idxint nCones = 0;

	// cost function
	pfloat c[4] = { 0, 0, -10, -17 };

	//cone
	idxint Gjc[5] = { 0, 1, 2, 3, 4 };
	idxint Gir[4] = { 0, 1, 2, 3 };
	pfloat Gpr[4] = { -1.0, -1.0, -1.0, -1.0 };
	pfloat h[4] = { 0.0, 0.0, 0.0, 0.0 };
	idxint *q = NULL;

	//lp matrix
	idxint Ajc[5] = { 0, 1, 2, 4, 6 };
	idxint Air[6] = { 0, 1, 0, 1, 0, 1 };
	pfloat Apr[6] = { 1, 1, 1, 5, 1, 9 };
	pfloat b[2] = { 12, 90 };
	idxint num_bool = 0;
	idxint *bool_idx = NULL;
	idxint num_int = 2;
	idxint int_idx[2] = { 2, 3 };
	ecos_bb_pwork *ILPHS18; idxint exitFlag;
	settings_bb * settings = get_default_ECOS_BB_settings();
	ILPHS18 = ECOS_BB_setup(n, m, p, l, nCones, q, 0, Gpr, Gjc, Gir, Apr, Ajc, Air, c, h, b, num_bool, bool_idx, num_int, int_idx, settings);
	exitFlag = ECOS_BB_solve(ILPHS18);
	ECOS_BB_cleanup(ILPHS18, 0);

this problem is solvable with ~6 iterations of branching. The current version cannot solve (and prove) it in 1000 iterations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/embotech/ecos/174)
<!-- Reviewable:end -->
