### PR TITLE
[ECOS BB] Implemented superior branching rules and new node selection method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,3 @@ python/dist
 python/*.pyc
 
 .vscode/
-vstudio/.vs/

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ runecos
 python/build
 python/dist
 python/*.pyc
+
+.vscode/
+vstudio/.vs/

--- a/ecos_bb/ecos_bb.c
+++ b/ecos_bb/ecos_bb.c
@@ -135,12 +135,12 @@ static void branch(idxint curr_node_idx, ecos_bb_pwork *prob)
     prob->nodes[prob->iter].prev_split_idx = split_idx;
     prob->nodes[prob->iter].prev_split_val = prob->nodes[curr_node_idx].split_val;
     prob->nodes[prob->iter].prev_relaxation = prob->nodes[curr_node_idx].relaxation;
-    prob->nodes[prob->iter].up_branch_node = TRUE;
+    prob->nodes[prob->iter].up_branch_node = 1;
 
     prob->nodes[curr_node_idx].prev_split_idx = split_idx;
     prob->nodes[curr_node_idx].prev_split_val = prob->nodes[curr_node_idx].split_val;
     prob->nodes[curr_node_idx].prev_relaxation = prob->nodes[curr_node_idx].relaxation;
-    prob->nodes[curr_node_idx].up_branch_node = FALSE;
+    prob->nodes[curr_node_idx].up_branch_node = 0;
 
     /* Copy over the node id*/
     for (i = 0; i < prob->num_bool_vars; ++i)
@@ -331,10 +331,10 @@ static char is_infeasible(idxint ecos_result)
         ecos_result == ECOS_DINF + ECOS_INACC_OFFSET ||
         ecos_result == ECOS_PINF + ECOS_INACC_OFFSET)
     {
-        return TRUE;
+        return 1;
     }
 
-    return FALSE;
+    return 0;
 }
 
 /*
@@ -399,7 +399,7 @@ static void calc_tmp_branching_problem(ecos_bb_pwork *problem, pfloat *relaxatio
 /*
  * Checks if the ecos result is infeasible, if so it fixes the variable to the other_val
  */
-static BOOL check_infeasible_bool_var(ecos_bb_pwork *problem, const idxint ecos_result, const pfloat relaxation, const idxint node_idx,
+static int check_infeasible_bool_var(ecos_bb_pwork *problem, const idxint ecos_result, const pfloat relaxation, const idxint node_idx,
                                       const char other_val, const idxint var_idx, idxint *split_idx, pfloat *split_val,
                                       const pfloat current_value)
 {
@@ -417,16 +417,16 @@ static BOOL check_infeasible_bool_var(ecos_bb_pwork *problem, const idxint ecos_
             *split_idx = var_idx;
             *split_val = current_value;
         }
-        return TRUE;
+        return 1;
     }
-    return FALSE;
+    return 0;
 }
 
 /*
  * Checks if the ecos result is infeasible, if so it fixes the variable
  */
-static BOOL check_infeasible_int_var(ecos_bb_pwork *problem, const idxint ecos_result, const pfloat relaxation, const idxint node_idx,
-                                     const BOOL fix_lb, const idxint var_idx, idxint *split_idx, pfloat *split_val,
+static int check_infeasible_int_var(ecos_bb_pwork *problem, const idxint ecos_result, const pfloat relaxation, const idxint node_idx,
+                                     const int fix_lb, const idxint var_idx, idxint *split_idx, pfloat *split_val,
                                      const pfloat current_value)
 {
     if (is_infeasible(ecos_result) || relaxation > problem->global_U)
@@ -446,16 +446,16 @@ static BOOL check_infeasible_int_var(ecos_bb_pwork *problem, const idxint ecos_r
             *split_idx = var_idx + problem->num_bool_vars;
             *split_val = current_value;
         }
-        return TRUE;
+        return 1;
     }
-    return FALSE;
+    return 0;
 }
 
 /*
  * calculates the q_down and q_up using strong-branching for a bool var
- * returns TRUE if one of the paths is infeasible
+ * returns 1 if one of the paths is infeasible
  */
-static BOOL strong_branch_bool_var(ecos_bb_pwork *problem, idxint *split_idx, pfloat *split_val, const idxint node_idx,
+static int strong_branch_bool_var(ecos_bb_pwork *problem, idxint *split_idx, pfloat *split_val, const idxint node_idx,
                                    pfloat *q_down, pfloat *q_up, const idxint i, const pfloat current_value)
 {
     // save val before branching
@@ -466,25 +466,25 @@ static BOOL strong_branch_bool_var(ecos_bb_pwork *problem, idxint *split_idx, pf
     calc_tmp_branching_problem(problem, q_down, &ecos_result);
     if (check_infeasible_bool_var(problem, ecos_result, *q_down, node_idx, MI_ONE, i, split_idx, split_val, current_value))
     {
-        return TRUE;
+        return 1;
     }
     // branch up
     problem->tmp_branching_bool_node_id[i] = MI_ONE;
     calc_tmp_branching_problem(problem, q_up, &ecos_result);
     if (check_infeasible_bool_var(problem, ecos_result, *q_up, node_idx, MI_ZERO, i, split_idx, split_val, current_value))
     {
-        return TRUE;
+        return 1;
     }
 
     problem->tmp_branching_bool_node_id[i] = orig_val;
-    return FALSE;
+    return 0;
 }
 
 /*
  * calculates the q_down and q_up using strong-branching for an int var
- * returns TRUE if one of the paths is infeasible
+ * returns 1 if one of the paths is infeasible
  */
-static BOOL strong_branch_int_var(ecos_bb_pwork *problem, idxint *split_idx, pfloat *split_val, idxint node_idx, pfloat *q_down, pfloat *q_up, idxint i, pfloat current_value)
+static int strong_branch_int_var(ecos_bb_pwork *problem, idxint *split_idx, pfloat *split_val, idxint node_idx, pfloat *q_down, pfloat *q_up, idxint i, pfloat current_value)
 {
     const idxint int_idx = i - problem->num_bool_vars;
     idxint ecos_result;
@@ -493,9 +493,9 @@ static BOOL strong_branch_int_var(ecos_bb_pwork *problem, idxint *split_idx, pfl
     problem->tmp_branching_int_node_id[2 * int_idx + 1] = pfloat_floor(current_value, problem->stgs->integer_tol);
     calc_tmp_branching_problem(problem, q_down, &ecos_result);
     problem->tmp_branching_int_node_id[2 * int_idx + 1] = orig_val;
-    if (check_infeasible_int_var(problem, ecos_result, *q_down, node_idx, TRUE, int_idx, split_idx, split_val, current_value))
+    if (check_infeasible_int_var(problem, ecos_result, *q_down, node_idx, 1, int_idx, split_idx, split_val, current_value))
     {
-        return TRUE;
+        return 1;
     }
 
     // branch up (set lower bound)
@@ -504,11 +504,11 @@ static BOOL strong_branch_int_var(ecos_bb_pwork *problem, idxint *split_idx, pfl
     calc_tmp_branching_problem(problem, q_up, &ecos_result);
 
     problem->tmp_branching_int_node_id[2 * int_idx] = orig_val;
-    if (check_infeasible_int_var(problem, ecos_result, *q_up, node_idx, FALSE, int_idx, split_idx, split_val, current_value))
+    if (check_infeasible_int_var(problem, ecos_result, *q_up, node_idx, 0, int_idx, split_idx, split_val, current_value))
     {
-        return TRUE;
+        return 1;
     }
-    return FALSE;
+    return 0;
 }
 
 /*
@@ -718,7 +718,7 @@ static void get_branch_var_pseudocost_branching(ecos_bb_pwork *problem, idxint *
 /*
  * Checks if the variable i is reliable enough for pseudocost branching
  */
-static BOOL is_reliable(ecos_bb_pwork *problem, const idxint i)
+static int is_reliable(ecos_bb_pwork *problem, const idxint i)
 {
     if (i < problem->num_bool_vars)
     {
@@ -740,7 +740,7 @@ static void get_branch_var_reliability_branching(ecos_bb_pwork *problem, idxint 
     pfloat up_psi, down_psi;
     idxint var_idx;
 
-    BOOL strong_initialized = FALSE;
+    int strong_initialized = 0;
 
     idxint ecos_result;
     pfloat q;
@@ -781,7 +781,7 @@ static void get_branch_var_reliability_branching(ecos_bb_pwork *problem, idxint 
             if (!strong_initialized)
             {
                 initialize_strong_branching(problem, node_idx);
-                strong_initialized = TRUE;
+                strong_initialized = 1;
 
                 calc_tmp_branching_problem(problem, &q, &ecos_result);
                 x_values = MALLOC(sizeof(pfloat) * problem->ecos_prob->n);

--- a/ecos_bb/ecos_bb.c
+++ b/ecos_bb/ecos_bb.c
@@ -345,7 +345,8 @@ static pfloat get_score(const pfloat delta_q_down, const pfloat delta_q_up)
 {
 
     const pfloat epsilon = 0.00000001;
-    return max(epsilon, delta_q_down) * max(epsilon, delta_q_up);
+	return (delta_q_down > epsilon ? delta_q_down : epsilon) * (delta_q_up > epsilon ? delta_q_up : epsilon);
+    
     // alternative score function using weighted avg
     // const pfloat mu = 1.0 / 6.0;
     // return (1 - mu) * min(delta_q_down, delta_q_up) + mu * max(delta_q_down, delta_q_up);
@@ -383,8 +384,9 @@ static void initialize_strong_branching(ecos_bb_pwork *problem, idxint node_idx)
     const int int_node_size = sizeof(pfloat) * 2 * problem->num_int_vars;
 
     // copy over current state to tmp_branching_nodes
-    memcpy_s(problem->tmp_branching_bool_node_id, bool_node_size, get_bool_node_id(node_idx, problem), bool_node_size);
-    memcpy_s(problem->tmp_branching_int_node_id, int_node_size, get_int_node_id(node_idx, problem), int_node_size);
+	
+    memcpy(problem->tmp_branching_bool_node_id, get_bool_node_id(node_idx, problem), bool_node_size);
+    memcpy(problem->tmp_branching_int_node_id, get_int_node_id(node_idx, problem), int_node_size);
 }
 
 /*
@@ -529,7 +531,7 @@ static void get_branch_var_strong_branching(ecos_bb_pwork *problem, idxint *spli
     pfloat q;
     calc_tmp_branching_problem(problem, &q, &ecos_result);
     pfloat *x_values = MALLOC(sizeof(pfloat) * problem->ecos_prob->n);
-    memcpy_s(x_values, sizeof(pfloat) * problem->ecos_prob->n, problem->ecos_prob->x, sizeof(pfloat) * problem->ecos_prob->n);
+    memcpy(x_values, problem->ecos_prob->x, sizeof(pfloat) * problem->ecos_prob->n);
 
     /* the lp-relaxation for the down branching solution */
     pfloat q_down;
@@ -790,7 +792,7 @@ static void get_branch_var_reliability_branching(ecos_bb_pwork *problem, idxint 
 
                 calc_tmp_branching_problem(problem, &q, &ecos_result);
                 x_values = MALLOC(sizeof(pfloat) * problem->ecos_prob->n);
-                memcpy_s(x_values, sizeof(pfloat) * problem->ecos_prob->n, problem->ecos_prob->x, sizeof(pfloat) * problem->ecos_prob->n);
+                memcpy(x_values, problem->ecos_prob->x, sizeof(pfloat) * problem->ecos_prob->n);
             }
 
             var_idx = i;

--- a/ecos_bb/ecos_bb.c
+++ b/ecos_bb/ecos_bb.c
@@ -17,7 +17,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 /*
  * The branch and bound module is (c) Han Wang, Stanford University,
  * [hanwang2@stanford.edu]
@@ -30,65 +29,84 @@
 #include "equil.h"
 #include "spla.h"
 
-#define MIN(X, Y)  ((X) < (Y) ? (X) : (Y))
+#define MIN(X, Y) ((X) < (Y) ? (X) : (Y))
 
 /* Print utility functions*/
 #if MI_PRINTLEVEL > 0
-static void print_progress(ecos_bb_pwork* prob){
-    PRINTTEXT("%u \t%.2f \t\t%.2f \t\t%.2f\n", (int)prob->iter, prob->global_L, prob->global_U, prob->global_U-prob->global_L);
+static void print_progress(ecos_bb_pwork *prob)
+{
+    PRINTTEXT("%u \t%.2f \t\t%.2f \t\t%.2f\n", (int)prob->iter, prob->global_L, prob->global_U, prob->global_U - prob->global_L);
 }
 
-static void print_ecos_solution(ecos_bb_pwork* prob){
-    int i; PRINTTEXT("ecos->x: ");
-    for(i=0; i < prob->ecos_prob->n; ++i) PRINTTEXT("%.2f ", prob->ecos_prob->x[i] );
+static void print_ecos_solution(ecos_bb_pwork *prob)
+{
+    int i;
+    PRINTTEXT("ecos->x: ");
+    for (i = 0; i < prob->ecos_prob->n; ++i)
+        PRINTTEXT("%.2f ", prob->ecos_prob->x[i]);
     PRINTTEXT("\n");
 }
 
-static void print_ecos_xequil(ecos_bb_pwork* prob){
+static void print_ecos_xequil(ecos_bb_pwork *prob)
+{
 #if EQUILIBRATE > 0
-    int i; PRINTTEXT("ecos->xequil: ");
-    for (i=0; i<prob->ecos_prob->n; ++i) PRINTTEXT("%.2f ", prob->ecos_prob->xequil[i] );
+    int i;
+    PRINTTEXT("ecos->xequil: ");
+    for (i = 0; i < prob->ecos_prob->n; ++i)
+        PRINTTEXT("%.2f ", prob->ecos_prob->xequil[i]);
 #else
     PRINTTEXT("ecos->xequil: 1, (equilibration dissabled) ");
 #endif
     PRINTTEXT("\n");
 }
 
-
-static void print_ecos_h(ecos_bb_pwork* prob){
-    int i; PRINTTEXT("ecos->h: ");
-    for (i=0; i<prob->ecos_prob->m; ++i) PRINTTEXT("%.2f ", prob->ecos_prob->h[i] );
+static void print_ecos_h(ecos_bb_pwork *prob)
+{
+    int i;
+    PRINTTEXT("ecos->h: ");
+    for (i = 0; i < prob->ecos_prob->m; ++i)
+        PRINTTEXT("%.2f ", prob->ecos_prob->h[i]);
     PRINTTEXT("\n");
 }
 
-static void print_ecos_c(ecos_bb_pwork* prob){
-    int i; PRINTTEXT("ecos->c: ");
-    for (i=0; i<prob->ecos_prob->n; ++i) PRINTTEXT("%.2f ", prob->ecos_prob->c[i] );
+static void print_ecos_c(ecos_bb_pwork *prob)
+{
+    int i;
+    PRINTTEXT("ecos->c: ");
+    for (i = 0; i < prob->ecos_prob->n; ++i)
+        PRINTTEXT("%.2f ", prob->ecos_prob->c[i]);
     PRINTTEXT("\n");
 }
 
-static void print_node(ecos_bb_pwork* prob, idxint i){
-    if (i==-1){
-        int j; PRINTTEXT("Node info: TMP, Partial id:");
-        for(j=0; j < prob->num_bool_vars; ++j)
-            PRINTTEXT("%i ", prob->tmp_bool_node_id[j] );
+static void print_node(ecos_bb_pwork *prob, idxint i)
+{
+    if (i == -1)
+    {
+        int j;
+        PRINTTEXT("Node info: TMP, Partial id:");
+        for (j = 0; j < prob->num_bool_vars; ++j)
+            PRINTTEXT("%i ", prob->tmp_bool_node_id[j]);
         PRINTTEXT(" | ");
-        for(j=0; j < prob->num_int_vars; ++j)
-            PRINTTEXT("(%.2f, %.2f) ", -prob->tmp_int_node_id[2*j], prob->tmp_int_node_id[2*j+1] );
+        for (j = 0; j < prob->num_int_vars; ++j)
+            PRINTTEXT("(%.2f, %.2f) ", -prob->tmp_int_node_id[2 * j], prob->tmp_int_node_id[2 * j + 1]);
         PRINTTEXT("\n");
-    }else{
-        int j; PRINTTEXT("Node info: %u : %.2f : %.2f : %u : %.2f Partial id:", prob->nodes[i].status,
-            prob->nodes[i].L, prob->nodes[i].U, (int)prob->nodes[i].split_idx, prob->nodes[i].split_val);
-        for(j=0; j < prob->num_bool_vars; ++j)
-            PRINTTEXT("%i ", get_bool_node_id(i, prob)[j] );
+    }
+    else
+    {
+        int j;
+        PRINTTEXT("Node info: %u : %.2f : %.2f : %u : %.2f Partial id:", prob->nodes[i].status,
+                  prob->nodes[i].L, prob->nodes[i].U, (int)prob->nodes[i].split_idx, prob->nodes[i].split_val);
+        for (j = 0; j < prob->num_bool_vars; ++j)
+            PRINTTEXT("%i ", get_bool_node_id(i, prob)[j]);
         PRINTTEXT(" | ");
-        for(j=0; j < prob->num_int_vars; ++j)
-            PRINTTEXT("(%.2f, %.2f) ", -get_int_node_id(i, prob)[2*j], get_int_node_id(i, prob)[2*j+1] );
+        for (j = 0; j < prob->num_int_vars; ++j)
+            PRINTTEXT("(%.2f, %.2f) ", -get_int_node_id(i, prob)[2 * j], get_int_node_id(i, prob)[2 * j + 1]);
         PRINTTEXT("\n");
     }
 }
 
-static void print_stats(ecos_bb_pwork* prob){
+static void print_stats(ecos_bb_pwork *prob)
+{
     PRINTTEXT("\tPcost: %.2f \n", prob->info->pcost);
     PRINTTEXT("\tDcost: %.2f \n", prob->info->dcost);
     PRINTTEXT("\tE_Pcost: %.2f \n", prob->ecos_prob->info->pcost);
@@ -96,12 +114,13 @@ static void print_stats(ecos_bb_pwork* prob){
 }
 #endif
 
-
-static void branch(idxint curr_node_idx, ecos_bb_pwork* prob){
+static void branch(idxint curr_node_idx, ecos_bb_pwork *prob)
+{
     idxint i, split_idx = prob->nodes[curr_node_idx].split_idx;
 
 #if MI_PRINTLEVEL > 1
-    if (prob->stgs->verbose) {
+    if (prob->stgs->verbose)
+    {
         PRINTTEXT("Branching->\t");
         print_node(prob, curr_node_idx);
     }
@@ -113,32 +132,38 @@ static void branch(idxint curr_node_idx, ecos_bb_pwork* prob){
     prob->nodes[prob->iter].status = MI_NOT_SOLVED;
 
     /* Copy over the node id*/
-    for(i=0; i < prob->num_bool_vars; ++i)
+    for (i = 0; i < prob->num_bool_vars; ++i)
         get_bool_node_id(prob->iter, prob)[i] = get_bool_node_id(curr_node_idx, prob)[i];
-    for(i=0; i < prob->num_int_vars*2; ++i)
+    for (i = 0; i < prob->num_int_vars * 2; ++i)
         get_int_node_id(prob->iter, prob)[i] = get_int_node_id(curr_node_idx, prob)[i];
 
-    if (split_idx < prob->num_bool_vars){
+    if (split_idx < prob->num_bool_vars)
+    {
         get_bool_node_id(curr_node_idx, prob)[split_idx] = MI_ZERO;
         get_bool_node_id(prob->iter, prob)[split_idx] = MI_ONE;
-    }else{
+    }
+    else
+    {
         split_idx -= prob->num_bool_vars;
 
         /* Left branch constrain UB */
-        get_int_node_id(curr_node_idx, prob)[split_idx*2 + 1] =
-            pfloat_floor( prob->nodes[curr_node_idx].split_val, prob->stgs->integer_tol );
+        get_int_node_id(curr_node_idx, prob)[split_idx * 2 + 1] =
+            pfloat_floor(prob->nodes[curr_node_idx].split_val, prob->stgs->integer_tol);
 
         /* Right branch constrain LB */
-        get_int_node_id(prob->iter, prob)[split_idx*2 ] =
-            -pfloat_ceil( prob->nodes[curr_node_idx].split_val, prob->stgs->integer_tol  );
+        get_int_node_id(prob->iter, prob)[split_idx * 2] =
+            -pfloat_ceil(prob->nodes[curr_node_idx].split_val, prob->stgs->integer_tol);
     }
 
     prob->nodes[curr_node_idx].status = MI_NOT_SOLVED;
 
 #if MI_PRINTLEVEL > 1
-    if (prob->stgs->verbose) {
-        PRINTTEXT(" Left-> \t "); print_node(prob, curr_node_idx);
-        PRINTTEXT(" Right->\t "); print_node(prob, prob->iter);
+    if (prob->stgs->verbose)
+    {
+        PRINTTEXT(" Left-> \t ");
+        print_node(prob, curr_node_idx);
+        PRINTTEXT(" Right->\t ");
+        print_node(prob, prob->iter);
     }
 #endif
 }
@@ -146,12 +171,15 @@ static void branch(idxint curr_node_idx, ecos_bb_pwork* prob){
 /*
  * Function to return the next node to be expanded
  */
-static idxint get_next_node(ecos_bb_pwork* prob){
+static idxint get_next_node(ecos_bb_pwork *prob)
+{
     idxint i;
     idxint next_node = -1;
     pfloat L = ECOS_INFINITY;
-    for(i=0; i <= prob->iter; ++i){
-        if(prob->nodes[i].status == MI_SOLVED_BRANCHABLE && prob->nodes[i].L < L ){
+    for (i = 0; i <= prob->iter; ++i)
+    {
+        if (prob->nodes[i].status == MI_SOLVED_BRANCHABLE && prob->nodes[i].L < L)
+        {
             next_node = i;
             L = prob->nodes[i].L;
         }
@@ -159,30 +187,38 @@ static idxint get_next_node(ecos_bb_pwork* prob){
     return next_node;
 }
 
-static pfloat get_global_L(ecos_bb_pwork* prob){
+static pfloat get_global_L(ecos_bb_pwork *prob)
+{
     idxint i;
     pfloat L = ECOS_INFINITY;
-    for(i=0; i <= prob->iter; ++i) L = MIN(L,prob->nodes[i].L);
+    for (i = 0; i <= prob->iter; ++i)
+        L = MIN(L, prob->nodes[i].L);
     return L;
 }
 
 /*
  * Function to return the next var to split on
  */
-static void get_branch_var(ecos_bb_pwork* prob, idxint* split_idx, pfloat* split_val){
+static void get_branch_var(ecos_bb_pwork *prob, idxint *split_idx, pfloat *split_val)
+{
     idxint i;
     pfloat x, y, d, ambiguity;
     d = 1.0;
-    for (i=0; i<(prob->num_bool_vars + prob->num_int_vars); ++i){
-        if (i < prob->num_bool_vars ){
-            y = prob->ecos_prob->x[ prob->bool_vars_idx[i] ];
+    for (i = 0; i < (prob->num_bool_vars + prob->num_int_vars); ++i)
+    {
+        if (i < prob->num_bool_vars)
+        {
+            y = prob->ecos_prob->x[prob->bool_vars_idx[i]];
             x = y;
-        } else {
-            y = prob->ecos_prob->x[ prob->int_vars_idx[i-prob->num_bool_vars] ];
-            x = y - pfloat_floor(y, prob->stgs->integer_tol );
         }
-        ambiguity = abs_2(x-0.5);
-        if ( ambiguity < d){
+        else
+        {
+            y = prob->ecos_prob->x[prob->int_vars_idx[i - prob->num_bool_vars]];
+            x = y - pfloat_floor(y, prob->stgs->integer_tol);
+        }
+        ambiguity = abs_2(x - 0.5);
+        if (ambiguity < d)
+        {
             *split_idx = i;
             *split_val = y;
             d = ambiguity;
@@ -197,80 +233,101 @@ static void get_branch_var(ecos_bb_pwork* prob, idxint* split_idx, pfloat* split
  * Updates the solver's lb and ub contraints for integer variables
  * to the bounds specified by the node
  */
-static void set_prob(ecos_bb_pwork* prob, char* bool_node_id, pfloat* int_node_id){
+static void set_prob(ecos_bb_pwork *prob, char *bool_node_id, pfloat *int_node_id)
+{
     idxint i;
-    for(i=0; i<prob->num_bool_vars; ++i){
-        switch(bool_node_id[i]){
-            case MI_ONE:
-                ecos_updateDataEntry_h(prob->ecos_prob, 2*i, -1.0); /*ecos_prob->h[2*i] = -(1.0); // -x <= -1 <=> x >= 1*/
-                ecos_updateDataEntry_h(prob->ecos_prob, 2*i+1, 1.0);/*ecos_prob->h[2*i + 1] = 1.0;*/
-                break;
-            case MI_ZERO:
-                ecos_updateDataEntry_h(prob->ecos_prob, 2*i, 0.0);/*ecos_prob->h[2*i] = 0.0;*/
-                ecos_updateDataEntry_h(prob->ecos_prob, 2*i+1, 0.0);/*ecos_prob->h[2*i + 1] = 0.0;*/
-                break;
-            case MI_STAR:
-                ecos_updateDataEntry_h(prob->ecos_prob, 2*i, 0.0);/*ecos_prob->h[2*i] = 0.0;*/
-                ecos_updateDataEntry_h(prob->ecos_prob, 2*i+1, 1.0);/*ecos_prob->h[2*i + 1] = 1.0;*/
-                break;
-			default:
+    for (i = 0; i < prob->num_bool_vars; ++i)
+    {
+        switch (bool_node_id[i])
+        {
+        case MI_ONE:
+            ecos_updateDataEntry_h(prob->ecos_prob, 2 * i, -1.0);    /*ecos_prob->h[2*i] = -(1.0); // -x <= -1 <=> x >= 1*/
+            ecos_updateDataEntry_h(prob->ecos_prob, 2 * i + 1, 1.0); /*ecos_prob->h[2*i + 1] = 1.0;*/
+            break;
+        case MI_ZERO:
+            ecos_updateDataEntry_h(prob->ecos_prob, 2 * i, 0.0);     /*ecos_prob->h[2*i] = 0.0;*/
+            ecos_updateDataEntry_h(prob->ecos_prob, 2 * i + 1, 0.0); /*ecos_prob->h[2*i + 1] = 0.0;*/
+            break;
+        case MI_STAR:
+            ecos_updateDataEntry_h(prob->ecos_prob, 2 * i, 0.0);     /*ecos_prob->h[2*i] = 0.0;*/
+            ecos_updateDataEntry_h(prob->ecos_prob, 2 * i + 1, 1.0); /*ecos_prob->h[2*i + 1] = 1.0;*/
+            break;
+        default:
 #if MI_PRINTLEVEL > 1
-				PRINTTEXT("Illegal boolean setting arguments passed: %u \n", bool_node_id[i]);
+            PRINTTEXT("Illegal boolean setting arguments passed: %u \n", bool_node_id[i]);
 #endif
-				break;
+            break;
         }
     }
 
     /* Set integer bounds */
-    for(i=0; i<prob->num_int_vars; ++i){
-        ecos_updateDataEntry_h(prob->ecos_prob, 2*(i + prob->num_bool_vars) , int_node_id[2*i] );
-        ecos_updateDataEntry_h(prob->ecos_prob, 2*(i + prob->num_bool_vars)+1 , int_node_id[2*i+1] );
+    for (i = 0; i < prob->num_int_vars; ++i)
+    {
+        ecos_updateDataEntry_h(prob->ecos_prob, 2 * (i + prob->num_bool_vars), int_node_id[2 * i]);
+        ecos_updateDataEntry_h(prob->ecos_prob, 2 * (i + prob->num_bool_vars) + 1, int_node_id[2 * i + 1]);
     }
 
 #if MI_PRINTLEVEL > 1
-    if (prob->stgs->verbose){ print_ecos_h(prob); }
+    if (prob->stgs->verbose)
+    {
+        print_ecos_h(prob);
+    }
 #endif
-
 }
 
 /*
  * Stores the ecos solution to the array inside ecos_bb
  */
-static void store_solution(ecos_bb_pwork* prob){
+static void store_solution(ecos_bb_pwork *prob)
+{
     idxint i;
-    for(i=0; i<prob->ecos_prob->n; ++i) prob->x[i] = prob->ecos_prob->x[i];
-    for(i=0; i<prob->ecos_prob->p; ++i) prob->y[i] = prob->ecos_prob->y[i];
-    for(i=0; i<prob->ecos_prob->m; ++i) prob->z[i] = prob->ecos_prob->z[i];
-    for(i=0; i<prob->ecos_prob->m; ++i) prob->s[i] = prob->ecos_prob->s[i];
-    prob->kap  =  prob->ecos_prob->kap ;
-    prob->tau  =  prob->ecos_prob->tau ;
+    for (i = 0; i < prob->ecos_prob->n; ++i)
+        prob->x[i] = prob->ecos_prob->x[i];
+    for (i = 0; i < prob->ecos_prob->p; ++i)
+        prob->y[i] = prob->ecos_prob->y[i];
+    for (i = 0; i < prob->ecos_prob->m; ++i)
+        prob->z[i] = prob->ecos_prob->z[i];
+    for (i = 0; i < prob->ecos_prob->m; ++i)
+        prob->s[i] = prob->ecos_prob->s[i];
+    prob->kap = prob->ecos_prob->kap;
+    prob->tau = prob->ecos_prob->tau;
     *(prob->info) = *(prob->ecos_prob->info);
 }
 
 /*
  * Loads the ecos_bb solution back into the ecos struct, necessary for the Matlab/Python interface
  */
-static void load_solution(ecos_bb_pwork* prob){
+static void load_solution(ecos_bb_pwork *prob)
+{
     idxint i;
-    for(i=0; i<prob->ecos_prob->n; ++i) prob->ecos_prob->x[i] = prob->x[i];
-    for(i=0; i<prob->ecos_prob->p; ++i) prob->ecos_prob->y[i] = prob->y[i];
-    for(i=0; i<prob->ecos_prob->m; ++i) prob->ecos_prob->z[i] = prob->z[i];
-    for(i=0; i<prob->ecos_prob->m; ++i) prob->ecos_prob->s[i] = prob->s[i];
+    for (i = 0; i < prob->ecos_prob->n; ++i)
+        prob->ecos_prob->x[i] = prob->x[i];
+    for (i = 0; i < prob->ecos_prob->p; ++i)
+        prob->ecos_prob->y[i] = prob->y[i];
+    for (i = 0; i < prob->ecos_prob->m; ++i)
+        prob->ecos_prob->z[i] = prob->z[i];
+    for (i = 0; i < prob->ecos_prob->m; ++i)
+        prob->ecos_prob->s[i] = prob->s[i];
     prob->ecos_prob->kap = prob->kap;
     prob->ecos_prob->tau = prob->tau;
     *(prob->ecos_prob->info) = *(prob->info);
 }
 
-static void get_bounds(idxint node_idx, ecos_bb_pwork* prob){
+static void get_bounds(idxint node_idx, ecos_bb_pwork *prob)
+{
     idxint i, ret_code, branchable, viable_rounded_sol;
     viable_rounded_sol = 0;
 
-    set_prob( prob, get_bool_node_id(node_idx,prob), get_int_node_id(node_idx, prob) );
+    set_prob(prob, get_bool_node_id(node_idx, prob), get_int_node_id(node_idx, prob));
     ret_code = ECOS_solve(prob->ecos_prob);
 
 #if MI_PRINTLEVEL > 1
-    if (prob->stgs->verbose){ print_ecos_solution(prob); }
-    if (ret_code != ECOS_OPTIMAL && ret_code != ECOS_PINF && ret_code != ECOS_DINF){
+    if (prob->stgs->verbose)
+    {
+        print_ecos_solution(prob);
+    }
+    if (ret_code != ECOS_OPTIMAL && ret_code != ECOS_PINF && ret_code != ECOS_DINF)
+    {
         PRINTTEXT("1Exit code: %u\n", ret_code);
     }
 #endif
@@ -278,58 +335,77 @@ static void get_bounds(idxint node_idx, ecos_bb_pwork* prob){
     if (ret_code == ECOS_OPTIMAL ||
         ret_code == ECOS_OPTIMAL + ECOS_INACC_OFFSET ||
         ret_code == ECOS_MAXIT ||
-        ret_code == ECOS_NUMERICS )
+        ret_code == ECOS_NUMERICS)
     {
         prob->nodes[node_idx].L = eddot(prob->ecos_prob->n, prob->ecos_prob->x, prob->ecos_prob->c);
 
         /* Figure out if x is already an integer solution
             if the solution had no numerical errors*/
         branchable = 1;
-        for (i=0; i<prob->num_bool_vars; ++i){
-            prob->tmp_bool_node_id[i] = (char) pfloat_round( prob->ecos_prob->x[prob->bool_vars_idx[i]] );
-            branchable &= float_eqls( prob->ecos_prob->x[prob->bool_vars_idx[i]] , (pfloat) prob->tmp_bool_node_id[i], prob->stgs->integer_tol );
+        for (i = 0; i < prob->num_bool_vars; ++i)
+        {
+            prob->tmp_bool_node_id[i] = (char)pfloat_round(prob->ecos_prob->x[prob->bool_vars_idx[i]]);
+            branchable &= float_eqls(prob->ecos_prob->x[prob->bool_vars_idx[i]], (pfloat)prob->tmp_bool_node_id[i], prob->stgs->integer_tol);
         }
-        for (i=0; i<prob->num_int_vars; ++i){
-            prob->tmp_int_node_id[2 * i + 1] = pfloat_round(prob->ecos_prob->x[prob->int_vars_idx[i]] );
-            prob->tmp_int_node_id[2*i] = -(prob->tmp_int_node_id[2*i + 1]);
-            branchable &= float_eqls( prob->ecos_prob->x[prob->int_vars_idx[i]] , prob->tmp_int_node_id[2*i + 1], prob->stgs->integer_tol );
+        for (i = 0; i < prob->num_int_vars; ++i)
+        {
+            prob->tmp_int_node_id[2 * i + 1] = pfloat_round(prob->ecos_prob->x[prob->int_vars_idx[i]]);
+            prob->tmp_int_node_id[2 * i] = -(prob->tmp_int_node_id[2 * i + 1]);
+            branchable &= float_eqls(prob->ecos_prob->x[prob->int_vars_idx[i]], prob->tmp_int_node_id[2 * i + 1], prob->stgs->integer_tol);
         }
         branchable = !branchable;
 
 #if MI_PRINTLEVEL > 1
-        if (prob->stgs->verbose){ PRINTTEXT("Is branchable: %u\n",branchable); }
+        if (prob->stgs->verbose)
+        {
+            PRINTTEXT("Is branchable: %u\n", branchable);
+        }
 #endif
 
-        if (branchable){ /* pfloat_round and check feasibility*/
-            get_branch_var(prob, &(prob->nodes[node_idx].split_idx), &(prob->nodes[node_idx].split_val) );
+        if (branchable)
+        { /* pfloat_round and check feasibility*/
+            get_branch_var(prob, &(prob->nodes[node_idx].split_idx), &(prob->nodes[node_idx].split_val));
             prob->nodes[node_idx].status = MI_SOLVED_BRANCHABLE;
 
 #if MI_PRINTLEVEL > 1
-            if (prob->stgs->verbose){ print_node(prob,-1); PRINTTEXT("Rounded Solution:\n"); }
+            if (prob->stgs->verbose)
+            {
+                print_node(prob, -1);
+                PRINTTEXT("Rounded Solution:\n");
+            }
 #endif
 
             set_prob(prob, prob->tmp_bool_node_id, prob->tmp_int_node_id);
             ret_code = ECOS_solve(prob->ecos_prob);
 
 #if MI_PRINTLEVEL > 1
-            if (prob->stgs->verbose){ print_ecos_solution(prob); }
-            if (ret_code != ECOS_OPTIMAL && ret_code != ECOS_PINF && ret_code != ECOS_DINF){
+            if (prob->stgs->verbose)
+            {
+                print_ecos_solution(prob);
+            }
+            if (ret_code != ECOS_OPTIMAL && ret_code != ECOS_PINF && ret_code != ECOS_DINF)
+            {
                 PRINTTEXT("2Exit code: %u\n", ret_code);
             }
 #endif
-            if (ret_code == ECOS_OPTIMAL){
+            if (ret_code == ECOS_OPTIMAL)
+            {
                 /* Use the node's U as tmp storage */
                 prob->nodes[node_idx].U = eddot(prob->ecos_prob->n, prob->ecos_prob->x, prob->ecos_prob->c);
                 viable_rounded_sol = 1;
             }
-        }else{ /* This is already an integer solution*/
+        }
+        else
+        { /* This is already an integer solution*/
             prob->nodes[node_idx].status = MI_SOLVED_NON_BRANCHABLE;
             prob->nodes[node_idx].U = eddot(prob->ecos_prob->n, prob->ecos_prob->x, prob->ecos_prob->c);
         }
 
-        if (prob->nodes[node_idx].U < prob->global_U){
+        if (prob->nodes[node_idx].U < prob->global_U)
+        {
 #if MI_PRINTLEVEL > 1
-            if (prob->stgs->verbose){
+            if (prob->stgs->verbose)
+            {
                 PRINTTEXT("New optimal solution, U: %.2f\n", prob->nodes[node_idx].U);
                 print_ecos_xequil(prob);
                 print_ecos_c(prob);
@@ -340,63 +416,85 @@ static void get_bounds(idxint node_idx, ecos_bb_pwork* prob){
             prob->global_U = prob->nodes[node_idx].U;
         }
 
-        if (viable_rounded_sol){
+        if (viable_rounded_sol)
+        {
             /* Reset the node's U back to INF because it was not originally feasible */
             prob->nodes[node_idx].U = ECOS_INFINITY;
         }
-
-    }else { /*Assume node infeasible*/
+    }
+    else
+    { /*Assume node infeasible*/
         prob->nodes[node_idx].L = ECOS_INFINITY;
         prob->nodes[node_idx].U = ECOS_INFINITY;
         prob->nodes[node_idx].status = MI_SOLVED_NON_BRANCHABLE;
     }
 }
 
-static idxint should_continue(ecos_bb_pwork* prob, idxint curr_node_idx){
-    return (prob->global_U - prob->global_L) > prob->stgs->abs_tol_gap
-        && abs_2(prob->global_U / prob->global_L - 1.0) > prob->stgs->rel_tol_gap
-        && curr_node_idx >= 0
-        && prob->iter < (prob->stgs->maxit-1);
+static idxint should_continue(ecos_bb_pwork *prob, idxint curr_node_idx)
+{
+    return (prob->global_U - prob->global_L) > prob->stgs->abs_tol_gap && abs_2(prob->global_U / prob->global_L - 1.0) > prob->stgs->rel_tol_gap && curr_node_idx >= 0 && prob->iter < (prob->stgs->maxit - 1);
 }
 
-static int get_ret_code(ecos_bb_pwork* prob){
-    if ( prob->iter < prob->stgs->maxit-1){
-        if ( isinf(prob->global_U) ){
-            if ( prob->global_U >= 0){
+static int get_ret_code(ecos_bb_pwork *prob)
+{
+    if (prob->iter < prob->stgs->maxit - 1)
+    {
+        if (isinf(prob->global_U))
+        {
+            if (prob->global_U >= 0)
+            {
                 return MI_INFEASIBLE;
-            }else{
+            }
+            else
+            {
                 return MI_UNBOUNDED;
             }
         }
-        else return MI_OPTIMAL_SOLN;
-    } else {
-        if ( isinf(prob->global_U) ){
-            if ( prob->global_U >= 0){
+        else
+            return MI_OPTIMAL_SOLN;
+    }
+    else
+    {
+        if (isinf(prob->global_U))
+        {
+            if (prob->global_U >= 0)
+            {
                 return MI_MAXITER_NO_SOLN;
-            }else{
+            }
+            else
+            {
                 return MI_MAXITER_UNBOUNDED;
             }
         }
-        else return MI_MAXITER_FEASIBLE_SOLN;
+        else
+            return MI_MAXITER_FEASIBLE_SOLN;
     }
 }
 
-static void initialize_root(ecos_bb_pwork* prob){
+static void initialize_root(ecos_bb_pwork *prob)
+{
     idxint i;
     prob->nodes[0].status = MI_NOT_SOLVED;
     prob->nodes[0].L = -ECOS_INFINITY;
-    prob->nodes[0].U =  ECOS_INFINITY;
+    prob->nodes[0].U = ECOS_INFINITY;
     prob->global_L = -ECOS_INFINITY;
     prob->global_U = ECOS_INFINITY;
-    for (i=0; i < prob->num_bool_vars; ++i) prob->bool_node_ids[i] = MI_STAR;
-    for (i=0; i < prob->num_int_vars; ++i) {prob->int_node_ids[2*i] = MAX_FLOAT_INT; prob->int_node_ids[2*i+1] = MAX_FLOAT_INT;}
+    for (i = 0; i < prob->num_bool_vars; ++i)
+        prob->bool_node_ids[i] = MI_STAR;
+    for (i = 0; i < prob->num_int_vars; ++i)
+    {
+        prob->int_node_ids[2 * i] = MAX_FLOAT_INT;
+        prob->int_node_ids[2 * i + 1] = MAX_FLOAT_INT;
+    }
 }
 
-idxint ECOS_BB_solve(ecos_bb_pwork* prob) {
+idxint ECOS_BB_solve(ecos_bb_pwork *prob)
+{
     idxint curr_node_idx = 0;
 
 #if MI_PRINTLEVEL > 0
-    if (prob->stgs->verbose){
+    if (prob->stgs->verbose)
+    {
         PRINTTEXT("Iter\tLower Bound\tUpper Bound\tGap\n");
         PRINTTEXT("================================================\n");
     }
@@ -412,10 +510,14 @@ idxint ECOS_BB_solve(ecos_bb_pwork* prob) {
     prob->global_L = prob->nodes[curr_node_idx].L;
     prob->global_U = prob->nodes[curr_node_idx].U;
 
-    while ( should_continue(prob, curr_node_idx) ){
+    while (should_continue(prob, curr_node_idx))
+    {
 
 #if MI_PRINTLEVEL > 0
-        if (prob->stgs->verbose){ print_progress(prob); }
+        if (prob->stgs->verbose)
+        {
+            print_progress(prob);
+        }
 #endif
 
         ++(prob->iter);
@@ -437,16 +539,21 @@ idxint ECOS_BB_solve(ecos_bb_pwork* prob) {
     load_solution(prob);
 
 #if MI_PRINTLEVEL > 0
-    if (prob->stgs->verbose){ print_progress(prob); }
+    if (prob->stgs->verbose)
+    {
+        print_progress(prob);
+    }
 #endif
 
     return get_ret_code(prob);
 }
 
-void updateDataEntry_h(ecos_bb_pwork* w, idxint idx, pfloat value){
-    ecos_updateDataEntry_h(w->ecos_prob, idx + (2*w->num_bool_vars), value);
+void updateDataEntry_h(ecos_bb_pwork *w, idxint idx, pfloat value)
+{
+    ecos_updateDataEntry_h(w->ecos_prob, idx + (2 * w->num_bool_vars), value);
 }
 
-void updateDataEntry_c(ecos_bb_pwork* w, idxint idx, pfloat value){
-    ecos_updateDataEntry_c(w->ecos_prob, idx , value);
+void updateDataEntry_c(ecos_bb_pwork *w, idxint idx, pfloat value)
+{
+    ecos_updateDataEntry_c(w->ecos_prob, idx, value);
 }

--- a/ecos_bb/ecos_bb.c
+++ b/ecos_bb/ecos_bb.c
@@ -18,9 +18,12 @@
  */
 
 /*
- * The branch and bound module is (c) Han Wang, Stanford University,
- * [hanwang2@stanford.edu]
- */
+   * The branch and bound module is (c) Han Wang, Stanford University,
+   * [hanwang2@stanford.edu]
+   *
+   * Extended with improved branching rules by Pascal Lüscher, student of FHNW
+   * [luescherpascal@gmail.com]
+   */
 
 #include "glblopts.h"
 #include "ecos.h"
@@ -94,8 +97,7 @@ static void print_node(ecos_bb_pwork *prob, idxint i)
     else
     {
         int j;
-        PRINTTEXT("Node info: %u : %.2f : %.2f : %u : %.2f Partial id:", prob->nodes[i].status,
-                  prob->nodes[i].L, prob->nodes[i].U, (int)prob->nodes[i].split_idx, prob->nodes[i].split_val);
+        PRINTTEXT("Node info %u: %u : %.2f : %.2f : %u : %.2f Partial id:", i, prob->nodes[i].status, prob->nodes[i].L, prob->nodes[i].U, (int)prob->nodes[i].split_idx, prob->nodes[i].split_val);
         for (j = 0; j < prob->num_bool_vars; ++j)
             PRINTTEXT("%i ", get_bool_node_id(i, prob)[j]);
         PRINTTEXT(" | ");
@@ -130,6 +132,15 @@ static void branch(idxint curr_node_idx, ecos_bb_pwork *prob)
     prob->nodes[prob->iter].L = prob->nodes[curr_node_idx].L;
     prob->nodes[prob->iter].U = prob->nodes[curr_node_idx].U;
     prob->nodes[prob->iter].status = MI_NOT_SOLVED;
+    prob->nodes[prob->iter].prev_split_idx = split_idx;
+    prob->nodes[prob->iter].prev_split_val = prob->nodes[curr_node_idx].split_val;
+    prob->nodes[prob->iter].prev_relaxation = prob->nodes[curr_node_idx].relaxation;
+    prob->nodes[prob->iter].up_branch_node = TRUE;
+
+    prob->nodes[curr_node_idx].prev_split_idx = split_idx;
+    prob->nodes[curr_node_idx].prev_split_val = prob->nodes[curr_node_idx].split_val;
+    prob->nodes[curr_node_idx].prev_relaxation = prob->nodes[curr_node_idx].relaxation;
+    prob->nodes[curr_node_idx].up_branch_node = FALSE;
 
     /* Copy over the node id*/
     for (i = 0; i < prob->num_bool_vars; ++i)
@@ -173,6 +184,16 @@ static void branch(idxint curr_node_idx, ecos_bb_pwork *prob)
  */
 static idxint get_next_node(ecos_bb_pwork *prob)
 {
+    if (prob->stgs->node_selection_method == DIVE_LOWER_NODE && prob->nodes[prob->dive_node_id].status == MI_SOLVED_BRANCHABLE)
+    {
+        return prob->dive_node_id;
+    }
+
+    if (prob->stgs->node_selection_method == DIVE_UPPER_NODE && prob->nodes[prob->iter].status == MI_SOLVED_BRANCHABLE)
+    {
+        return prob->iter;
+    }
+
     idxint i;
     idxint next_node = -1;
     pfloat L = ECOS_INFINITY;
@@ -184,6 +205,7 @@ static idxint get_next_node(ecos_bb_pwork *prob)
             L = prob->nodes[i].L;
         }
     }
+    prob->dive_node_id = next_node;
     return next_node;
 }
 
@@ -198,8 +220,9 @@ static pfloat get_global_L(ecos_bb_pwork *prob)
 
 /*
  * Function to return the next var to split on
+ * using most infeasible branching
  */
-static void get_branch_var(ecos_bb_pwork *prob, idxint *split_idx, pfloat *split_val)
+static void get_branch_var_most_infeasible(ecos_bb_pwork *prob, idxint *split_idx, pfloat *split_val)
 {
     idxint i;
     pfloat x, y, d, ambiguity;
@@ -223,6 +246,32 @@ static void get_branch_var(ecos_bb_pwork *prob, idxint *split_idx, pfloat *split
             *split_val = y;
             d = ambiguity;
         }
+    }
+#if MI_PRINTLEVEL > 1
+    PRINTTEXT("split_idx:%u, split_val:%f\n", *split_idx, *split_val);
+#endif
+}
+
+/*
+ * Function to return the next var to split on
+ * using random branching
+ */
+static void get_branch_var_random(ecos_bb_pwork *prob, idxint *split_idx, pfloat *split_val)
+{
+    while (1)
+    {
+        idxint i = rand() % (prob->num_bool_vars + prob->num_int_vars);
+        *split_val = i < prob->num_bool_vars
+                         ? prob->ecos_prob->x[prob->bool_vars_idx[i]]
+                         : prob->ecos_prob->x[prob->int_vars_idx[i - prob->num_bool_vars]];
+        *split_idx = i;
+        if (float_eqls(*split_val, pfloat_floor(*split_val, prob->stgs->integer_tol), prob->stgs->integer_tol) ||
+            float_eqls(*split_val, pfloat_ceil(*split_val, prob->stgs->integer_tol), prob->stgs->integer_tol))
+        {
+            continue;
+        }
+
+        break;
     }
 #if MI_PRINTLEVEL > 1
     PRINTTEXT("split_idx:%u, split_val:%f\n", *split_idx, *split_val);
@@ -272,6 +321,520 @@ static void set_prob(ecos_bb_pwork *prob, char *bool_node_id, pfloat *int_node_i
     {
         print_ecos_h(prob);
     }
+#endif
+}
+
+static char is_infeasible(idxint ecos_result)
+{
+    if (ecos_result == ECOS_DINF ||
+        ecos_result == ECOS_PINF ||
+        ecos_result == ECOS_DINF + ECOS_INACC_OFFSET ||
+        ecos_result == ECOS_PINF + ECOS_INACC_OFFSET)
+    {
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
+/*
+ * returns the score for down / up branching.
+ * Using the product, same method is used in SCIP
+ */
+static pfloat get_score(const pfloat delta_q_down, const pfloat delta_q_up)
+{
+
+    const pfloat epsilon = 0.00000001;
+    return max(epsilon, delta_q_down) * max(epsilon, delta_q_up);
+    // alternative score function using weighted avg
+    // const pfloat mu = 1.0 / 6.0;
+    // return (1 - mu) * min(delta_q_down, delta_q_up) + mu * max(delta_q_down, delta_q_up);
+}
+
+/*
+ * Creates a new array with length n with random sorted idxints
+ */
+static idxint *get_shuffled_array(const idxint n)
+{
+    idxint *ret_val = MALLOC(n * sizeof(idxint));
+    for (idxint i = 0; i < n; ++i)
+    {
+        ret_val[i] = i;
+    }
+
+    for (idxint i = 0; i < n - 1; i++)
+    {
+        idxint j = i + rand() / (RAND_MAX / (n - i) + 1);
+        const idxint t = ret_val[j];
+        ret_val[j] = ret_val[i];
+        ret_val[i] = t;
+    }
+    return ret_val;
+}
+
+/**
+ * Initializes strong branching by copying current state in tmp_branching nodes
+ */
+static void initialize_strong_branching(ecos_bb_pwork *problem, idxint node_idx)
+{
+    // copy away tmp bool and int node since it's needed by another function -.-
+    const int bool_node_size = sizeof(char) * problem->num_bool_vars;
+    const int int_node_size = sizeof(pfloat) * 2 * problem->num_int_vars;
+
+    // copy over current state to tmp_branching_nodes
+    memcpy_s(problem->tmp_branching_bool_node_id, bool_node_size, get_bool_node_id(node_idx, problem), bool_node_size);
+    memcpy_s(problem->tmp_branching_int_node_id, int_node_size, get_int_node_id(node_idx, problem), int_node_size);
+}
+
+/*
+ * Calculates the relaxation (and ecos_result) for the tmp_branching node
+ */
+static void calc_tmp_branching_problem(ecos_bb_pwork *problem, pfloat *relaxation, idxint *ecos_result)
+{
+    set_prob(problem, problem->tmp_branching_bool_node_id, problem->tmp_branching_int_node_id);
+    *ecos_result = ECOS_solve(problem->ecos_prob);
+    *relaxation = eddot(problem->ecos_prob->n, problem->ecos_prob->x, problem->ecos_prob->c);
+}
+
+/*
+ * Checks if the ecos result is infeasible, if so it fixes the variable to the other_val
+ */
+static BOOL check_infeasible_bool_var(ecos_bb_pwork *problem, const idxint ecos_result, const pfloat relaxation, const idxint node_idx,
+                                      const char other_val, const idxint var_idx, idxint *split_idx, pfloat *split_val,
+                                      const pfloat current_value)
+{
+    if (is_infeasible(ecos_result) || relaxation > problem->global_U)
+    {
+        //fix value to MI_ONE, no branching needed
+        get_bool_node_id(node_idx, problem)[var_idx] = other_val;
+        problem->tmp_branching_bool_node_id[var_idx] = other_val;
+#if PRINTLEVEL >= 3
+        PRINTTEXT("Found infeasible node path for down-branching in node [%d] in var [%d]\n", node_idx, i);
+#endif
+        // prevent to have no branching variable set because of continuing
+        if (*split_idx == -1)
+        {
+            *split_idx = var_idx;
+            *split_val = current_value;
+        }
+        return TRUE;
+    }
+    return FALSE;
+}
+
+/*
+ * Checks if the ecos result is infeasible, if so it fixes the variable
+ */
+static BOOL check_infeasible_int_var(ecos_bb_pwork *problem, const idxint ecos_result, const pfloat relaxation, const idxint node_idx,
+                                     const BOOL fix_lb, const idxint var_idx, idxint *split_idx, pfloat *split_val,
+                                     const pfloat current_value)
+{
+    if (is_infeasible(ecos_result) || relaxation > problem->global_U)
+    {
+        // fix lower bound
+        const pfloat fix_val = fix_lb
+                                   ? -pfloat_ceil(current_value, problem->stgs->integer_tol)
+                                   : pfloat_floor(current_value, problem->stgs->integer_tol);
+        get_int_node_id(node_idx, problem)[2 * var_idx + (fix_lb ? 0 : 1)] = fix_val;
+        problem->tmp_branching_int_node_id[2 * var_idx + (fix_lb ? 0 : 1)] = fix_val;
+#if PRINTLEVEL >= 3
+        PRINTTEXT("Found infeasible node path for down-branching in node [%d] in var [%d]\n", node_idx, i);
+#endif
+        // prevent to have no branching variable set because of continuing
+        if (*split_idx == -1)
+        {
+            *split_idx = var_idx + problem->num_bool_vars;
+            *split_val = current_value;
+        }
+        return TRUE;
+    }
+    return FALSE;
+}
+
+/*
+ * calculates the q_down and q_up using strong-branching for a bool var
+ * returns TRUE if one of the paths is infeasible
+ */
+static BOOL strong_branch_bool_var(ecos_bb_pwork *problem, idxint *split_idx, pfloat *split_val, const idxint node_idx,
+                                   pfloat *q_down, pfloat *q_up, const idxint i, const pfloat current_value)
+{
+    // save val before branching
+    const char orig_val = problem->tmp_branching_bool_node_id[i];
+    idxint ecos_result;
+    // branch down
+    problem->tmp_branching_bool_node_id[i] = MI_ZERO;
+    calc_tmp_branching_problem(problem, q_down, &ecos_result);
+    if (check_infeasible_bool_var(problem, ecos_result, *q_down, node_idx, MI_ONE, i, split_idx, split_val, current_value))
+    {
+        return TRUE;
+    }
+    // branch up
+    problem->tmp_branching_bool_node_id[i] = MI_ONE;
+    calc_tmp_branching_problem(problem, q_up, &ecos_result);
+    if (check_infeasible_bool_var(problem, ecos_result, *q_up, node_idx, MI_ZERO, i, split_idx, split_val, current_value))
+    {
+        return TRUE;
+    }
+
+    problem->tmp_branching_bool_node_id[i] = orig_val;
+    return FALSE;
+}
+
+/*
+ * calculates the q_down and q_up using strong-branching for an int var
+ * returns TRUE if one of the paths is infeasible
+ */
+static BOOL strong_branch_int_var(ecos_bb_pwork *problem, idxint *split_idx, pfloat *split_val, idxint node_idx, pfloat *q_down, pfloat *q_up, idxint i, pfloat current_value)
+{
+    const idxint int_idx = i - problem->num_bool_vars;
+    idxint ecos_result;
+    // branch down (set upper bound)
+    pfloat orig_val = problem->tmp_branching_int_node_id[2 * int_idx + 1];
+    problem->tmp_branching_int_node_id[2 * int_idx + 1] = pfloat_floor(current_value, problem->stgs->integer_tol);
+    calc_tmp_branching_problem(problem, q_down, &ecos_result);
+    problem->tmp_branching_int_node_id[2 * int_idx + 1] = orig_val;
+    if (check_infeasible_int_var(problem, ecos_result, *q_down, node_idx, TRUE, int_idx, split_idx, split_val, current_value))
+    {
+        return TRUE;
+    }
+
+    // branch up (set lower bound)
+    orig_val = problem->tmp_branching_int_node_id[2 * int_idx];
+    problem->tmp_branching_int_node_id[2 * int_idx] = -pfloat_ceil(current_value, problem->stgs->integer_tol);
+    calc_tmp_branching_problem(problem, q_up, &ecos_result);
+
+    problem->tmp_branching_int_node_id[2 * int_idx] = orig_val;
+    if (check_infeasible_int_var(problem, ecos_result, *q_up, node_idx, FALSE, int_idx, split_idx, split_val, current_value))
+    {
+        return TRUE;
+    }
+    return FALSE;
+}
+
+/*
+ * Function to return the next var to split on
+ */
+static void get_branch_var_strong_branching(ecos_bb_pwork *problem, idxint *split_idx, pfloat *split_val, idxint node_idx)
+{
+    /* id of either bool index or int index */
+    idxint var_id;
+    /* best cost based on get_score */
+    pfloat best_score = -ECOS_INFINITY;
+
+    initialize_strong_branching(problem, node_idx);
+
+    /* calc current lp relaxation and save x vector */
+    idxint ecos_result;
+    pfloat q;
+    calc_tmp_branching_problem(problem, &q, &ecos_result);
+    pfloat *x_values = MALLOC(sizeof(pfloat) * problem->ecos_prob->n);
+    memcpy_s(x_values, sizeof(pfloat) * problem->ecos_prob->n, problem->ecos_prob->x, sizeof(pfloat) * problem->ecos_prob->n);
+
+    /* the lp-relaxation for the down branching solution */
+    pfloat q_down;
+    /* the lp-relaxation for the up branching solution */
+    pfloat q_up;
+
+    pfloat best_q_down = 0.0, best_q_up = 0.0;
+
+    idxint orig_maxit = problem->ecos_prob->stgs->maxit;
+    idxint orig_maxit_bk = problem->ecos_prob->stgs->max_bk_iter;
+    /* set split idx to something impossible */
+    *split_idx = -1;
+
+    idxint *random_idx = get_shuffled_array(problem->num_bool_vars + problem->num_int_vars);
+    for (idxint rand_i = 0; rand_i < problem->num_bool_vars + problem->num_int_vars; ++rand_i)
+    {
+        idxint const i = random_idx[rand_i];
+
+        if (i < problem->num_bool_vars)
+        {
+            var_id = problem->bool_vars_idx[i];
+        }
+        else
+        {
+
+            var_id = problem->int_vars_idx[i - problem->num_bool_vars];
+        }
+        pfloat current_value = x_values[var_id];
+        // if already int, skip candidate
+        if (float_eqls(current_value, pfloat_floor(current_value, problem->stgs->integer_tol), problem->stgs->integer_tol) ||
+            float_eqls(current_value, pfloat_ceil(current_value, problem->stgs->integer_tol), problem->stgs->integer_tol))
+        {
+            continue;
+        }
+
+        if (i < problem->num_bool_vars)
+        {
+            if (strong_branch_bool_var(problem, split_idx, split_val, node_idx, &q_down, &q_up, i, current_value))
+                continue;
+        }
+        else
+        {
+            if (strong_branch_int_var(problem, split_idx, split_val, node_idx, &q_down, &q_up, i, current_value))
+                continue;
+        }
+
+        const pfloat curr_score = get_score(q_down - q, q_up - q);
+        if (curr_score > best_score)
+        {
+            *split_idx = i;
+            *split_val = current_value;
+            best_q_down = q_down;
+            best_q_up = q_up;
+
+            best_score = curr_score;
+        }
+    }
+    free(x_values);
+
+    problem->ecos_prob->stgs->maxit = orig_maxit;
+    problem->ecos_prob->stgs->max_bk_iter = orig_maxit_bk;
+
+#if MI_PRINTLEVEL >= 3
+    PRINTTEXT("split_idx: %u, split_val: %f,q: %f, q_down: %f, q_up: %f\n", *split_idx, *split_val, q, best_q_down, best_q_up);
+#endif
+}
+
+/*
+ * returns the average pseudocost values
+ */
+static pfloat avg_pseudocost(pfloat *pseudocost_sums, idxint *pseudocost_cnts, const int pseudocost_sums_cnt, const char up)
+{
+    pfloat sum = 0.0;
+    int cnt = 0;
+    for (int i = 0; i < pseudocost_sums_cnt; ++i)
+    {
+        if (pseudocost_cnts[2 * i + up] > 0)
+        {
+            sum += pseudocost_sums[2 * i + up];
+            cnt += pseudocost_cnts[2 * i + up];
+        }
+    }
+    if (cnt > 0)
+    {
+        return sum / cnt;
+    }
+    return 1.0;
+}
+
+/*
+ * calculates the psi values for pseudocosts
+ */
+static void set_pseudocost_psi(ecos_bb_pwork *problem, const idxint i, pfloat *down_psi, pfloat *up_psi)
+{
+    if (i < problem->num_bool_vars)
+    {
+        if (problem->pseudocost_bin_cnt[2 * i] == 0)
+        {
+            *down_psi = avg_pseudocost(problem->pseudocost_bin_sum, problem->pseudocost_bin_cnt, problem->num_bool_vars, 0);
+        }
+        else
+        {
+            *down_psi = (problem->pseudocost_bin_sum[2 * i] / problem->pseudocost_bin_cnt[2 * i]);
+        }
+
+        if (problem->pseudocost_bin_cnt[2 * i + 1] == 0)
+        {
+            *up_psi = avg_pseudocost(problem->pseudocost_bin_sum, problem->pseudocost_bin_cnt, problem->num_bool_vars, 1);
+        }
+        else
+        {
+            *up_psi = (problem->pseudocost_bin_sum[2 * i + 1] / problem->pseudocost_bin_cnt[2 * i + 1]);
+        }
+    }
+    else
+    {
+        idxint var_idx = i - problem->num_bool_vars;
+        if (problem->pseudocost_int_cnt[2 * var_idx] == 0)
+        {
+            *down_psi = avg_pseudocost(problem->pseudocost_int_sum, problem->pseudocost_int_cnt, problem->num_int_vars, 0);
+        }
+        else
+        {
+            *down_psi = (problem->pseudocost_int_sum[2 * var_idx] / problem->pseudocost_int_cnt[2 * var_idx]);
+            ;
+        }
+
+        if (problem->pseudocost_int_cnt[2 * var_idx + 1] == 0)
+        {
+            *up_psi = avg_pseudocost(problem->pseudocost_int_sum, problem->pseudocost_int_cnt, problem->num_int_vars, 1);
+        }
+        else
+        {
+            *up_psi = (problem->pseudocost_int_sum[2 * var_idx + 1] / problem->pseudocost_int_cnt[2 * var_idx + 1]);
+        }
+    }
+}
+
+/*
+ * Function to return the next var to split on
+ * using pure pseudocost branching
+ */
+static void get_branch_var_pseudocost_branching(ecos_bb_pwork *problem, idxint *split_idx, pfloat *split_val, idxint node_idx)
+{
+    pfloat high_score = -ECOS_INFINITY;
+    pfloat up_psi, down_psi;
+    idxint var_idx;
+    idxint *random_idx = get_shuffled_array(problem->num_bool_vars + problem->num_int_vars);
+    for (idxint rand_i = 0; rand_i < problem->num_bool_vars + problem->num_int_vars; ++rand_i)
+    {
+        idxint const i = random_idx[rand_i];
+        if (i < problem->num_bool_vars)
+        {
+            var_idx = problem->bool_vars_idx[i];
+        }
+        else
+        {
+            var_idx = problem->int_vars_idx[(i - problem->num_bool_vars)];
+        }
+
+        pfloat y = problem->ecos_prob->x[var_idx];
+        if (float_eqls(y, pfloat_floor(y, problem->stgs->integer_tol), problem->stgs->integer_tol) ||
+            float_eqls(y, pfloat_ceil(y, problem->stgs->integer_tol), problem->stgs->integer_tol))
+        {
+            continue;
+        }
+
+        set_pseudocost_psi(problem, i, &down_psi, &up_psi);
+        const pfloat down_change_in_var = y - pfloat_floor(y, problem->stgs->integer_tol);
+        const pfloat up_change_in_var = 1.0 - down_change_in_var;
+
+        const pfloat score = get_score(down_change_in_var * down_psi, up_change_in_var * up_psi);
+
+        if (score > high_score)
+        {
+            *split_idx = i;
+            *split_val = y;
+            high_score = score;
+        }
+    }
+
+#if MI_PRINTLEVEL > 1
+    PRINTTEXT("split_idx:%u, split_val:%f\n", *split_idx, *split_val);
+#endif
+}
+
+/*
+ * Checks if the variable i is reliable enough for pseudocost branching
+ */
+static BOOL is_reliable(ecos_bb_pwork *problem, const idxint i)
+{
+    if (i < problem->num_bool_vars)
+    {
+        return problem->pseudocost_bin_cnt[2 * i] > problem->stgs->reliable_eta &&
+               problem->pseudocost_bin_cnt[2 * i + 1] > problem->stgs->reliable_eta;
+    }
+    return problem->pseudocost_int_cnt[2 * (i - problem->num_bool_vars)] > problem->stgs->reliable_eta &&
+           problem->pseudocost_int_cnt[2 * (i - problem->num_bool_vars) + 1] > problem->stgs->reliable_eta;
+}
+
+/*
+ * Function to return the next var to split on
+ * using reliability branching
+ */
+static void get_branch_var_reliability_branching(ecos_bb_pwork *problem, idxint *split_idx, pfloat *split_val, const idxint node_idx)
+{
+    pfloat score;
+    pfloat high_score = -ECOS_INFINITY;
+    pfloat up_psi, down_psi;
+    idxint var_idx;
+
+    BOOL strong_initialized = FALSE;
+
+    idxint ecos_result;
+    pfloat q;
+    pfloat *x_values = NULL;
+
+    idxint *random_idx = get_shuffled_array(problem->num_bool_vars + problem->num_int_vars);
+    for (idxint rand_i = 0; rand_i < problem->num_bool_vars + problem->num_int_vars; ++rand_i)
+    {
+        idxint const i = random_idx[rand_i];
+
+        if (i < problem->num_bool_vars)
+        {
+            var_idx = problem->bool_vars_idx[i];
+        }
+        else
+        {
+            var_idx = problem->int_vars_idx[(i - problem->num_bool_vars)];
+        }
+
+        const pfloat y = problem->ecos_prob->x[var_idx];
+        if (float_eqls(y, pfloat_floor(y, problem->stgs->integer_tol), problem->stgs->integer_tol) ||
+            float_eqls(y, pfloat_ceil(y, problem->stgs->integer_tol), problem->stgs->integer_tol))
+        {
+            continue;
+        }
+
+        if (is_reliable(problem, i))
+        {
+            set_pseudocost_psi(problem, i, &down_psi, &up_psi);
+
+            const pfloat down_change_in_var = y - pfloat_floor(y, problem->stgs->integer_tol);
+            const pfloat up_change_in_var = 1.0 - down_change_in_var;
+
+            score = get_score(down_change_in_var * down_psi, up_change_in_var * up_psi);
+        }
+        else
+        {
+            if (!strong_initialized)
+            {
+                initialize_strong_branching(problem, node_idx);
+                strong_initialized = TRUE;
+
+                calc_tmp_branching_problem(problem, &q, &ecos_result);
+                x_values = MALLOC(sizeof(pfloat) * problem->ecos_prob->n);
+                memcpy_s(x_values, sizeof(pfloat) * problem->ecos_prob->n, problem->ecos_prob->x, sizeof(pfloat) * problem->ecos_prob->n);
+            }
+
+            var_idx = i;
+
+            pfloat q_down, q_up;
+            pfloat *sum_ptr;
+            idxint *cnt_ptr;
+            pfloat current_value;
+            if (i < problem->num_bool_vars)
+            {
+                current_value = x_values[problem->bool_vars_idx[var_idx]];
+                if (strong_branch_bool_var(problem, split_idx, split_val, node_idx, &q_down, &q_up, i, current_value))
+                {
+                    continue;
+                }
+                sum_ptr = problem->pseudocost_bin_sum;
+                cnt_ptr = problem->pseudocost_bin_cnt;
+            }
+            else
+            {
+                var_idx = i - problem->num_bool_vars;
+                current_value = x_values[problem->int_vars_idx[var_idx]];
+                if (strong_branch_int_var(problem, split_idx, split_val, node_idx, &q_down, &q_up, i, x_values[problem->int_vars_idx[var_idx]]))
+                {
+                    continue;
+                }
+                sum_ptr = problem->pseudocost_int_sum;
+                cnt_ptr = problem->pseudocost_int_cnt;
+            }
+            const pfloat var_change_up = pfloat_ceil(current_value, problem->stgs->integer_tol) - current_value;
+            const pfloat var_change_down = current_value - pfloat_floor(current_value, problem->stgs->integer_tol);
+            sum_ptr[2 * var_idx] += (q_down - q) / var_change_down;
+            cnt_ptr[2 * var_idx] += 1;
+            sum_ptr[2 * var_idx + 1] += (q_up - q) / var_change_up;
+            cnt_ptr[2 * var_idx + 1] += 1;
+
+            score = get_score(q_down - q, q_up - q);
+        }
+
+        if (score > high_score)
+        {
+            *split_idx = i;
+            *split_val = y;
+            high_score = score;
+        }
+    }
+
+#if MI_PRINTLEVEL > 1
+    PRINTTEXT("split_idx:%u, split_val:%f\n", *split_idx, *split_val);
 #endif
 }
 
@@ -339,8 +902,45 @@ static void get_bounds(idxint node_idx, ecos_bb_pwork *prob)
     {
         prob->nodes[node_idx].L = eddot(prob->ecos_prob->n, prob->ecos_prob->x, prob->ecos_prob->c);
 
+        // if global best known solution is better than our lower
+        if (prob->global_U < prob->nodes[node_idx].L)
+        {
+            prob->nodes[node_idx].status = MI_SOLVED_NON_BRANCHABLE;
+            return;
+        }
+
+        prob->nodes[node_idx].relaxation = eddot(prob->ecos_prob->n, prob->ecos_prob->x, prob->ecos_prob->c);
+
+        // update pseudocost_values
+        if (prob->nodes[node_idx].prev_split_idx >= 0)
+        {
+            idxint split_idx = prob->nodes[node_idx].prev_split_idx;
+            const idxint offset = prob->nodes[node_idx].up_branch_node ? 1 : 0;
+
+            const pfloat change_in_q = prob->nodes[node_idx].relaxation - prob->nodes[node_idx].prev_relaxation;
+            const pfloat change_in_var = prob->nodes[node_idx].up_branch_node
+                                             ? pfloat_ceil(prob->nodes[node_idx].prev_split_val, prob->stgs->integer_tol) - prob->nodes[node_idx].prev_split_val
+                                             : prob->nodes[node_idx].prev_split_val - pfloat_floor(prob->nodes[node_idx].prev_split_val, prob->stgs->integer_tol);
+
+            pfloat *sum_ptr;
+            idxint *cnt_ptr;
+            if (split_idx < prob->num_bool_vars)
+            {
+                sum_ptr = &prob->pseudocost_bin_sum[2 * split_idx + offset];
+                cnt_ptr = &prob->pseudocost_bin_cnt[2 * split_idx + offset];
+            }
+            else
+            {
+                split_idx -= prob->num_bool_vars;
+                sum_ptr = &prob->pseudocost_int_sum[2 * split_idx + offset];
+                cnt_ptr = &prob->pseudocost_int_cnt[2 * split_idx + offset];
+            }
+            *sum_ptr += change_in_q / change_in_var;
+            *cnt_ptr += 1;
+        }
+
         /* Figure out if x is already an integer solution
-            if the solution had no numerical errors*/
+			if the solution had no numerical errors*/
         branchable = 1;
         for (i = 0; i < prob->num_bool_vars; ++i)
         {
@@ -364,7 +964,25 @@ static void get_bounds(idxint node_idx, ecos_bb_pwork *prob)
 
         if (branchable)
         { /* pfloat_round and check feasibility*/
-            get_branch_var(prob, &(prob->nodes[node_idx].split_idx), &(prob->nodes[node_idx].split_val));
+            switch (prob->stgs->branching_strategy)
+            {
+            case BRANCHING_STRATEGY_MOST_INFEASIBLE:
+                get_branch_var_most_infeasible(prob, &(prob->nodes[node_idx].split_idx), &(prob->nodes[node_idx].split_val));
+                break;
+            case BRANCHING_STRATEGY_STRONG_BRANCHING:
+                get_branch_var_strong_branching(prob, &(prob->nodes[node_idx].split_idx), &(prob->nodes[node_idx].split_val), node_idx);
+                break;
+            case BRANCHING_STRATEGY_PSEUDOCOST_BRANCHING:
+                get_branch_var_pseudocost_branching(prob, &(prob->nodes[node_idx].split_idx), &(prob->nodes[node_idx].split_val), node_idx);
+                break;
+            case BRANCHING_STRATEGY_RELIABILITY:
+                get_branch_var_reliability_branching(prob, &(prob->nodes[node_idx].split_idx), &(prob->nodes[node_idx].split_val), node_idx);
+                break;
+            case BRANCHING_STRATEGY_RANDOM:
+                get_branch_var_random(prob, &(prob->nodes[node_idx].split_idx), &(prob->nodes[node_idx].split_val));
+            default:;
+            }
+
             prob->nodes[node_idx].status = MI_SOLVED_BRANCHABLE;
 
 #if MI_PRINTLEVEL > 1
@@ -374,7 +992,6 @@ static void get_bounds(idxint node_idx, ecos_bb_pwork *prob)
                 PRINTTEXT("Rounded Solution:\n");
             }
 #endif
-
             set_prob(prob, prob->tmp_bool_node_id, prob->tmp_int_node_id);
             ret_code = ECOS_solve(prob->ecos_prob);
 
@@ -420,6 +1037,12 @@ static void get_bounds(idxint node_idx, ecos_bb_pwork *prob)
         {
             /* Reset the node's U back to INF because it was not originally feasible */
             prob->nodes[node_idx].U = ECOS_INFINITY;
+        }
+
+        // if global best known solution is better than our lower
+        if (prob->global_U < prob->nodes[node_idx].L)
+        {
+            prob->nodes[node_idx].status = MI_SOLVED_NON_BRANCHABLE;
         }
     }
     else
@@ -477,6 +1100,7 @@ static void initialize_root(ecos_bb_pwork *prob)
     prob->nodes[0].status = MI_NOT_SOLVED;
     prob->nodes[0].L = -ECOS_INFINITY;
     prob->nodes[0].U = ECOS_INFINITY;
+    prob->nodes[0].prev_split_idx = -1;
     prob->global_L = -ECOS_INFINITY;
     prob->global_U = ECOS_INFINITY;
     for (i = 0; i < prob->num_bool_vars; ++i)
@@ -503,6 +1127,7 @@ idxint ECOS_BB_solve(ecos_bb_pwork *prob)
     /* Initialize to root node and execute steps 1 on slide 6 */
     /* of http://stanford.edu/class/ee364b/lectures/bb_slides.pdf*/
     prob->iter = 0;
+    prob->dive_node_id = 0;
     initialize_root(prob);
     /*print_node(prob, curr_node_idx);*/
     get_bounds(curr_node_idx, prob);
@@ -544,7 +1169,6 @@ idxint ECOS_BB_solve(ecos_bb_pwork *prob)
         print_progress(prob);
     }
 #endif
-
     return get_ret_code(prob);
 }
 

--- a/ecos_bb/ecos_bb.c
+++ b/ecos_bb/ecos_bb.c
@@ -357,12 +357,13 @@ static pfloat get_score(const pfloat delta_q_down, const pfloat delta_q_up)
 static idxint *get_shuffled_array(const idxint n)
 {
     idxint *ret_val = MALLOC(n * sizeof(idxint));
-    for (idxint i = 0; i < n; ++i)
+    idxint i;
+    for (i = 0; i < n; ++i)
     {
         ret_val[i] = i;
     }
 
-    for (idxint i = 0; i < n - 1; i++)
+    for (i = 0; i < n - 1; i++)
     {
         idxint j = i + rand() / (RAND_MAX / (n - i) + 1);
         const idxint t = ret_val[j];
@@ -543,7 +544,8 @@ static void get_branch_var_strong_branching(ecos_bb_pwork *problem, idxint *spli
     *split_idx = -1;
 
     idxint *random_idx = get_shuffled_array(problem->num_bool_vars + problem->num_int_vars);
-    for (idxint rand_i = 0; rand_i < problem->num_bool_vars + problem->num_int_vars; ++rand_i)
+    idxint rand_i;
+    for (rand_i = 0; rand_i < problem->num_bool_vars + problem->num_int_vars; ++rand_i)
     {
         idxint const i = random_idx[rand_i];
 
@@ -602,8 +604,9 @@ static void get_branch_var_strong_branching(ecos_bb_pwork *problem, idxint *spli
 static pfloat avg_pseudocost(pfloat *pseudocost_sums, idxint *pseudocost_cnts, const int pseudocost_sums_cnt, const char up)
 {
     pfloat sum = 0.0;
-    int cnt = 0;
-    for (int i = 0; i < pseudocost_sums_cnt; ++i)
+    idxint cnt = 0;
+    idxint i = 0;
+    for (i = 0; i < pseudocost_sums_cnt; ++i)
     {
         if (pseudocost_cnts[2 * i + up] > 0)
         {
@@ -677,7 +680,8 @@ static void get_branch_var_pseudocost_branching(ecos_bb_pwork *problem, idxint *
     pfloat up_psi, down_psi;
     idxint var_idx;
     idxint *random_idx = get_shuffled_array(problem->num_bool_vars + problem->num_int_vars);
-    for (idxint rand_i = 0; rand_i < problem->num_bool_vars + problem->num_int_vars; ++rand_i)
+    idxint rand_i;
+    for (rand_i = 0; rand_i < problem->num_bool_vars + problem->num_int_vars; ++rand_i)
     {
         idxint const i = random_idx[rand_i];
         if (i < problem->num_bool_vars)
@@ -747,7 +751,8 @@ static void get_branch_var_reliability_branching(ecos_bb_pwork *problem, idxint 
     pfloat *x_values = NULL;
 
     idxint *random_idx = get_shuffled_array(problem->num_bool_vars + problem->num_int_vars);
-    for (idxint rand_i = 0; rand_i < problem->num_bool_vars + problem->num_int_vars; ++rand_i)
+    idxint rand_i;
+    for (rand_i = 0; rand_i < problem->num_bool_vars + problem->num_int_vars; ++rand_i)
     {
         idxint const i = random_idx[rand_i];
 

--- a/ecos_bb/ecos_bb.c
+++ b/ecos_bb/ecos_bb.c
@@ -840,6 +840,7 @@ static void get_branch_var_reliability_branching(ecos_bb_pwork *problem, idxint 
         }
     }
     free(random_idx);
+    free(x_values);
 #if MI_PRINTLEVEL > 1
     PRINTTEXT("split_idx:%u, split_val:%f\n", *split_idx, *split_val);
 #endif

--- a/ecos_bb/ecos_bb.c
+++ b/ecos_bb/ecos_bb.c
@@ -199,7 +199,7 @@ static idxint get_next_node(ecos_bb_pwork *prob)
     pfloat L = ECOS_INFINITY;
     for (i = 0; i <= prob->iter; ++i)
     {
-        if (prob->nodes[i].status == MI_SOLVED_BRANCHABLE && prob->nodes[i].L < L)
+        if (prob->nodes[i].status == MI_SOLVED_BRANCHABLE && prob->nodes[i].L < L && prob->nodes[i].L < prob->global_U)
         {
             next_node = i;
             L = prob->nodes[i].L;

--- a/ecos_bb/ecos_bb.c
+++ b/ecos_bb/ecos_bb.c
@@ -345,8 +345,8 @@ static pfloat get_score(const pfloat delta_q_down, const pfloat delta_q_up)
 {
 
     const pfloat epsilon = 0.00000001;
-	return (delta_q_down > epsilon ? delta_q_down : epsilon) * (delta_q_up > epsilon ? delta_q_up : epsilon);
-    
+    return (delta_q_down > epsilon ? delta_q_down : epsilon) * (delta_q_up > epsilon ? delta_q_up : epsilon);
+
     // alternative score function using weighted avg
     // const pfloat mu = 1.0 / 6.0;
     // return (1 - mu) * min(delta_q_down, delta_q_up) + mu * max(delta_q_down, delta_q_up);
@@ -384,7 +384,7 @@ static void initialize_strong_branching(ecos_bb_pwork *problem, idxint node_idx)
     const int int_node_size = sizeof(pfloat) * 2 * problem->num_int_vars;
 
     // copy over current state to tmp_branching_nodes
-	
+
     memcpy(problem->tmp_branching_bool_node_id, get_bool_node_id(node_idx, problem), bool_node_size);
     memcpy(problem->tmp_branching_int_node_id, get_int_node_id(node_idx, problem), int_node_size);
 }
@@ -403,8 +403,8 @@ static void calc_tmp_branching_problem(ecos_bb_pwork *problem, pfloat *relaxatio
  * Checks if the ecos result is infeasible, if so it fixes the variable to the other_val
  */
 static int check_infeasible_bool_var(ecos_bb_pwork *problem, const idxint ecos_result, const pfloat relaxation, const idxint node_idx,
-                                      const char other_val, const idxint var_idx, idxint *split_idx, pfloat *split_val,
-                                      const pfloat current_value)
+                                     const char other_val, const idxint var_idx, idxint *split_idx, pfloat *split_val,
+                                     const pfloat current_value)
 {
     if (is_infeasible(ecos_result) || relaxation > problem->global_U)
     {
@@ -429,8 +429,8 @@ static int check_infeasible_bool_var(ecos_bb_pwork *problem, const idxint ecos_r
  * Checks if the ecos result is infeasible, if so it fixes the variable
  */
 static int check_infeasible_int_var(ecos_bb_pwork *problem, const idxint ecos_result, const pfloat relaxation, const idxint node_idx,
-                                     const int fix_lb, const idxint var_idx, idxint *split_idx, pfloat *split_val,
-                                     const pfloat current_value)
+                                    const int fix_lb, const idxint var_idx, idxint *split_idx, pfloat *split_val,
+                                    const pfloat current_value)
 {
     if (is_infeasible(ecos_result) || relaxation > problem->global_U)
     {
@@ -459,7 +459,7 @@ static int check_infeasible_int_var(ecos_bb_pwork *problem, const idxint ecos_re
  * returns 1 if one of the paths is infeasible
  */
 static int strong_branch_bool_var(ecos_bb_pwork *problem, idxint *split_idx, pfloat *split_val, const idxint node_idx,
-                                   pfloat *q_down, pfloat *q_up, const idxint i, const pfloat current_value)
+                                  pfloat *q_down, pfloat *q_up, const idxint i, const pfloat current_value)
 {
     // save val before branching
     const char orig_val = problem->tmp_branching_bool_node_id[i];
@@ -591,7 +591,7 @@ static void get_branch_var_strong_branching(ecos_bb_pwork *problem, idxint *spli
         }
     }
     free(x_values);
-
+    free(random_idx);
     problem->ecos_prob->stgs->maxit = orig_maxit;
     problem->ecos_prob->stgs->max_bk_iter = orig_maxit_bk;
 
@@ -715,7 +715,7 @@ static void get_branch_var_pseudocost_branching(ecos_bb_pwork *problem, idxint *
             high_score = score;
         }
     }
-
+    free(random_idx);
 #if MI_PRINTLEVEL > 1
     PRINTTEXT("split_idx:%u, split_val:%f\n", *split_idx, *split_val);
 #endif
@@ -839,7 +839,7 @@ static void get_branch_var_reliability_branching(ecos_bb_pwork *problem, idxint 
             high_score = score;
         }
     }
-
+    free(random_idx);
 #if MI_PRINTLEVEL > 1
     PRINTTEXT("split_idx:%u, split_val:%f\n", *split_idx, *split_val);
 #endif

--- a/ecos_bb/ecos_bb_preproc.c
+++ b/ecos_bb/ecos_bb_preproc.c
@@ -17,7 +17,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 /*
  * The branch and bound module is (c) Han Wang, Stanford University,
  * [hanwang2@stanford.edu]
@@ -41,13 +40,15 @@
 #define CALLOC calloc
 #endif
 
-static int contains(idxint idx, idxint num_int, idxint* bool_vars_idx){
+static int contains(idxint idx, idxint num_int, idxint *bool_vars_idx)
+{
     idxint i;
     idxint ans = 0;
-    for (i=0; i<num_int; ++i){
+    for (i = 0; i < num_int; ++i)
+    {
         ans += (bool_vars_idx[i] == idx);
     }
-    return (int) ans;
+    return (int)ans;
 }
 
 /* Augments the G and b arrays to take lb and ub constraints
@@ -55,98 +56,111 @@ static int contains(idxint idx, idxint num_int, idxint* bool_vars_idx){
  * USES MALLOC
  */
 static void socp_to_ecos_bb(
-    idxint num_bool_vars, idxint* bool_vars_idx,
-    idxint num_int_vars, idxint* int_vars_idx,
+    idxint num_bool_vars, idxint *bool_vars_idx,
+    idxint num_int_vars, idxint *int_vars_idx,
     idxint n, idxint m,
-    pfloat* Gpr_in, idxint* Gjc_in, idxint* Gir_in,
-    pfloat* Gpr_out, idxint* Gjc_out, idxint* Gir_out,
-    pfloat* h_in, pfloat* h_out)
+    pfloat *Gpr_in, idxint *Gjc_in, idxint *Gir_in,
+    pfloat *Gpr_out, idxint *Gjc_out, idxint *Gir_out,
+    pfloat *h_in, pfloat *h_out)
 {
     idxint i, j, k;
 
     /* First map in the column pointers, remember Gir_out[0]=0*/
-    for (i=0; i<=n; ++i){
+    for (i = 0; i <= n; ++i)
+    {
         Gjc_out[i] = Gjc_in[i];
     }
 
-    j=0;
-    for (i=0; i<n; ++i){
-        if (contains(i, num_bool_vars, bool_vars_idx)){
-            Gpr_out[ Gjc_out[i] ] = -1;
-            Gpr_out[ Gjc_out[i] + 1 ] = 1;
+    j = 0;
+    for (i = 0; i < n; ++i)
+    {
+        if (contains(i, num_bool_vars, bool_vars_idx))
+        {
+            Gpr_out[Gjc_out[i]] = -1;
+            Gpr_out[Gjc_out[i] + 1] = 1;
 
-            Gir_out[ Gjc_out[i] ] = 2*j;
-            Gir_out[ Gjc_out[i] + 1 ] = 2*j + 1;
+            Gir_out[Gjc_out[i]] = 2 * j;
+            Gir_out[Gjc_out[i] + 1] = 2 * j + 1;
 
             /* Set lower bound to 0*/
-            h_out[ 2*j ] = 0;
+            h_out[2 * j] = 0;
 
             /* Set upper bound to 1*/
-            h_out[ 2*j + 1] = 1;
+            h_out[2 * j + 1] = 1;
 
             /* Expand the following arrays */
-            for (k=(i+1); k<=n; ++k){
+            for (k = (i + 1); k <= n; ++k)
+            {
                 Gjc_out[k] += 2;
             }
 
             /* Now fill in the array */
-            for(k=0; k<(Gjc_in[i+1] - Gjc_in[i]); ++k){
-                Gpr_out[Gjc_out[i]+2+k] = Gpr_in[Gjc_in[i]+k];
-                Gir_out[Gjc_out[i]+2+k] = Gir_in[Gjc_in[i]+k] + 2*num_bool_vars + 2*num_int_vars;
+            for (k = 0; k < (Gjc_in[i + 1] - Gjc_in[i]); ++k)
+            {
+                Gpr_out[Gjc_out[i] + 2 + k] = Gpr_in[Gjc_in[i] + k];
+                Gir_out[Gjc_out[i] + 2 + k] = Gir_in[Gjc_in[i] + k] + 2 * num_bool_vars + 2 * num_int_vars;
             }
 
             ++j;
-        }else if (contains(i, num_int_vars, int_vars_idx)){
-            Gpr_out[ Gjc_out[i] ] = -1;
-            Gpr_out[ Gjc_out[i] + 1 ] = 1;
+        }
+        else if (contains(i, num_int_vars, int_vars_idx))
+        {
+            Gpr_out[Gjc_out[i]] = -1;
+            Gpr_out[Gjc_out[i] + 1] = 1;
 
-            Gir_out[ Gjc_out[i] ] = 2*j;
-            Gir_out[ Gjc_out[i] + 1 ] = 2*j + 1;
+            Gir_out[Gjc_out[i]] = 2 * j;
+            Gir_out[Gjc_out[i] + 1] = 2 * j + 1;
 
             /* Set lower bound to 0*/
-            h_out[ 2*j ] = MAX_FLOAT_INT;
+            h_out[2 * j] = MAX_FLOAT_INT;
 
             /* Set upper bound to 1*/
-            h_out[ 2*j + 1] = MAX_FLOAT_INT;
+            h_out[2 * j + 1] = MAX_FLOAT_INT;
 
             /* Expand the following arrays */
-            for (k=(i+1); k<=n; ++k){
+            for (k = (i + 1); k <= n; ++k)
+            {
                 Gjc_out[k] += 2;
             }
 
             /* Now fill in the array */
-            for(k=0; k<(Gjc_in[i+1] - Gjc_in[i]); ++k){
-                Gpr_out[Gjc_out[i]+2+k] = Gpr_in[Gjc_in[i]+k];
-                Gir_out[Gjc_out[i]+2+k] = Gir_in[Gjc_in[i]+k] + 2*num_bool_vars + 2*num_int_vars;
+            for (k = 0; k < (Gjc_in[i + 1] - Gjc_in[i]); ++k)
+            {
+                Gpr_out[Gjc_out[i] + 2 + k] = Gpr_in[Gjc_in[i] + k];
+                Gir_out[Gjc_out[i] + 2 + k] = Gir_in[Gjc_in[i] + k] + 2 * num_bool_vars + 2 * num_int_vars;
             }
 
             ++j;
-        }else{
-            for(k=0; k<(Gjc_in[i+1] - Gjc_in[i]); ++k){
-                Gpr_out[Gjc_out[i]+k] = Gpr_in[Gjc_in[i]+k];
-                Gir_out[Gjc_out[i]+k] = Gir_in[Gjc_in[i]+k] + 2*num_bool_vars + 2*num_int_vars;
+        }
+        else
+        {
+            for (k = 0; k < (Gjc_in[i + 1] - Gjc_in[i]); ++k)
+            {
+                Gpr_out[Gjc_out[i] + k] = Gpr_in[Gjc_in[i] + k];
+                Gir_out[Gjc_out[i] + k] = Gir_in[Gjc_in[i] + k] + 2 * num_bool_vars + 2 * num_int_vars;
             }
         }
     }
 
     /* Copy the remaining entries of b*/
-    for (i=0; i<m; ++i){
-        h_out[2*(num_bool_vars + num_int_vars) + i] = h_in[i];
+    for (i = 0; i < m; ++i)
+    {
+        h_out[2 * (num_bool_vars + num_int_vars) + i] = h_in[i];
     }
 }
 
-ecos_bb_pwork* ECOS_BB_setup(
+ecos_bb_pwork *ECOS_BB_setup(
     idxint n, idxint m, idxint p,
-    idxint l, idxint ncones, idxint* q, idxint nex,
-    pfloat* Gpr, idxint* Gjc, idxint* Gir,
-    pfloat* Apr, idxint* Ajc, idxint* Air,
-    pfloat* c, pfloat* h, pfloat* b,
-    idxint num_bool_vars, idxint* bool_vars_idx,
-    idxint num_int_vars, idxint* int_vars_idx,
-    settings_bb* stgs)
+    idxint l, idxint ncones, idxint *q, idxint nex,
+    pfloat *Gpr, idxint *Gjc, idxint *Gir,
+    pfloat *Apr, idxint *Ajc, idxint *Air,
+    pfloat *c, pfloat *h, pfloat *b,
+    idxint num_bool_vars, idxint *bool_vars_idx,
+    idxint num_int_vars, idxint *int_vars_idx,
+    settings_bb *stgs)
 {
     idxint new_G_size;
-    ecos_bb_pwork* prob;
+    ecos_bb_pwork *prob;
 
 #if MI_PRINTLEVEL > 2
     int i;
@@ -161,38 +175,60 @@ ecos_bb_pwork* ECOS_BB_setup(
     PRINTTEXT("  ****************************************************************\n");
     PRINTTEXT("\n\n");
     PRINTTEXT("PROBLEM SUMMARY:\n");
-    PRINTTEXT("   Boolean variables (num_bool_vars): %d\n", (int) num_bool_vars);
-    PRINTTEXT("   Integer variables ( num_int_vars): %d\n", (int) num_int_vars);
+    PRINTTEXT("   Boolean variables (num_bool_vars): %d\n", (int)num_bool_vars);
+    PRINTTEXT("   Integer variables ( num_int_vars): %d\n", (int)num_int_vars);
     PRINTTEXT("- - - - - - - - - - - - - - -\n");
-    PRINTTEXT("   Boolean var indices: "); for( i=0; i<num_bool_vars; ++i) PRINTTEXT("%u ", (unsigned int) bool_vars_idx[i]); PRINTTEXT("\n");
-    PRINTTEXT("   Integer var indices: "); for( i=0; i<num_int_vars; ++i) PRINTTEXT("%u ", (unsigned int) int_vars_idx[i]); PRINTTEXT("\n");
+    PRINTTEXT("   Boolean var indices: ");
+    for (i = 0; i < num_bool_vars; ++i)
+        PRINTTEXT("%u ", (unsigned int)bool_vars_idx[i]);
+    PRINTTEXT("\n");
+    PRINTTEXT("   Integer var indices: ");
+    for (i = 0; i < num_int_vars; ++i)
+        PRINTTEXT("%u ", (unsigned int)int_vars_idx[i]);
+    PRINTTEXT("\n");
     PRINTTEXT("\n");
 
-    PRINTTEXT("n=%u\n",n);
-    PRINTTEXT("m=%u\n",m);
-    PRINTTEXT("Gpr=");for (i=0;i<Gjc[n];i++){PRINTTEXT("%f,",Gpr[i]);}PRINTTEXT("\n");
-    PRINTTEXT("Gir=");for (i=0;i<Gjc[n];i++){PRINTTEXT("%u,",Gir[i]);}PRINTTEXT("\n");
-    PRINTTEXT("Gjc=");for (i=0;i<=n;i++){PRINTTEXT("%u,",Gjc[i]);}PRINTTEXT("\n");
+    PRINTTEXT("n=%u\n", n);
+    PRINTTEXT("m=%u\n", m);
+    PRINTTEXT("Gpr=");
+    for (i = 0; i < Gjc[n]; i++)
+    {
+        PRINTTEXT("%f,", Gpr[i]);
+    }
+    PRINTTEXT("\n");
+    PRINTTEXT("Gir=");
+    for (i = 0; i < Gjc[n]; i++)
+    {
+        PRINTTEXT("%u,", Gir[i]);
+    }
+    PRINTTEXT("\n");
+    PRINTTEXT("Gjc=");
+    for (i = 0; i <= n; i++)
+    {
+        PRINTTEXT("%u,", Gjc[i]);
+    }
+    PRINTTEXT("\n");
 #endif
 
-
-
     /* MALLOC the problem's memory*/
-    prob = (ecos_bb_pwork*) MALLOC(sizeof(ecos_bb_pwork));
+    prob = (ecos_bb_pwork *)MALLOC(sizeof(ecos_bb_pwork));
 
-    if (stgs == NULL){
+    if (stgs == NULL)
+    {
         stgs = get_default_ECOS_BB_settings();
         prob->default_settings = 1;
-    }else{
+    }
+    else
+    {
         prob->default_settings = 0;
     }
     prob->stgs = stgs;
 
-    new_G_size = Gjc[n] + (2*num_bool_vars) + (2*num_int_vars);
-    prob->Gpr_new = (pfloat *) MALLOC( new_G_size*sizeof(pfloat) );
-    prob->Gjc_new = (idxint *) MALLOC( (n+1) * sizeof(idxint) );
-    prob->Gir_new = (idxint *) MALLOC( new_G_size*sizeof(idxint) );
-    prob->h_new   = (pfloat *) MALLOC( (m + 2*num_bool_vars + 2*num_int_vars) * sizeof(pfloat) );
+    new_G_size = Gjc[n] + (2 * num_bool_vars) + (2 * num_int_vars);
+    prob->Gpr_new = (pfloat *)MALLOC(new_G_size * sizeof(pfloat));
+    prob->Gjc_new = (idxint *)MALLOC((n + 1) * sizeof(idxint));
+    prob->Gir_new = (idxint *)MALLOC(new_G_size * sizeof(idxint));
+    prob->h_new = (pfloat *)MALLOC((m + 2 * num_bool_vars + 2 * num_int_vars) * sizeof(pfloat));
 
     /* Copy the data and convert it to boolean*/
     socp_to_ecos_bb(num_bool_vars, bool_vars_idx,
@@ -201,31 +237,30 @@ ecos_bb_pwork* ECOS_BB_setup(
                     Gpr, Gjc, Gir,
                     prob->Gpr_new, prob->Gjc_new, prob->Gir_new,
                     h, prob->h_new);
-    m += 2*(num_bool_vars + num_int_vars);
-    l += 2*(num_bool_vars + num_int_vars);
+    m += 2 * (num_bool_vars + num_int_vars);
+    l += 2 * (num_bool_vars + num_int_vars);
 
     /* MALLOC the initial node's book keeping data #(2*maxIter)*/
-    prob->nodes = (node*) CALLOC( prob->stgs->maxit, sizeof(node) );
+    prob->nodes = (node *)CALLOC(prob->stgs->maxit, sizeof(node));
 
     /* MALLOC the id arrays*/
-    prob->bool_node_ids = (char*)  MALLOC( prob->stgs->maxit*num_bool_vars*sizeof(char) );
-    prob->int_node_ids = (pfloat*) MALLOC( 2*prob->stgs->maxit*num_int_vars*sizeof(pfloat) );
+    prob->bool_node_ids = (char *)MALLOC(prob->stgs->maxit * num_bool_vars * sizeof(char));
+    prob->int_node_ids = (pfloat *)MALLOC(2 * prob->stgs->maxit * num_int_vars * sizeof(pfloat));
 
     /* MALLOC the tmp node id*/
-    prob->tmp_bool_node_id = (char*) MALLOC( num_bool_vars*sizeof(char) );
-    prob->tmp_int_node_id = (pfloat*) MALLOC( 2*num_int_vars*sizeof(pfloat) );
+    prob->tmp_bool_node_id = (char *)MALLOC(num_bool_vars * sizeof(char));
+    prob->tmp_int_node_id = (pfloat *)MALLOC(2 * num_int_vars * sizeof(pfloat));
 
     /* Store the pointer to the boolean idx*/
     prob->bool_vars_idx = bool_vars_idx;
     prob->int_vars_idx = int_vars_idx;
 
     /* MALLOC the best optimal solution's memory*/
-    prob->x = (pfloat*) MALLOC( n*sizeof(pfloat) );
-    prob->y = (pfloat*) MALLOC( p*sizeof(pfloat) );
-    prob->z = (pfloat*) MALLOC( m*sizeof(pfloat) );
-    prob->s = (pfloat*) MALLOC( m*sizeof(pfloat) );
-    prob->info = (stats*) MALLOC( sizeof(stats) );
-
+    prob->x = (pfloat *)MALLOC(n * sizeof(pfloat));
+    prob->y = (pfloat *)MALLOC(p * sizeof(pfloat));
+    prob->z = (pfloat *)MALLOC(m * sizeof(pfloat));
+    prob->s = (pfloat *)MALLOC(m * sizeof(pfloat));
+    prob->info = (stats *)MALLOC(sizeof(stats));
 
     /* Setup the ecos solver*/
     prob->ecos_prob = ECOS_setup(
@@ -241,7 +276,7 @@ ecos_bb_pwork* ECOS_BB_setup(
     prob->global_U = ECOS_INFINITY;
 
     /* offset the h pointer for the user*/
-    prob->h = &prob->ecos_prob->h[ 2*(num_bool_vars + num_int_vars) ];
+    prob->h = &prob->ecos_prob->h[2 * (num_bool_vars + num_int_vars)];
 
     /* Map the other variables*/
     prob->A = prob->ecos_prob->A;
@@ -263,11 +298,11 @@ ecos_bb_pwork* ECOS_BB_setup(
 #endif
 
     PRINTTEXT("ECOS h: ");
-    for (i=0; i<m; ++i){
-        PRINTTEXT("%.2f ", prob->ecos_prob->h[i] );
+    for (i = 0; i < m; ++i)
+    {
+        PRINTTEXT("%.2f ", prob->ecos_prob->h[i]);
     }
     PRINTTEXT("\n");
-
 
     PRINTTEXT("\n");
 #endif
@@ -276,7 +311,8 @@ ecos_bb_pwork* ECOS_BB_setup(
 }
 
 /* Performs the same function as ecos_cleanup*/
-void ECOS_BB_cleanup(ecos_bb_pwork* prob, idxint num_vars_keep){
+void ECOS_BB_cleanup(ecos_bb_pwork *prob, idxint num_vars_keep)
+{
     /* FREE solver memory*/
     ECOS_cleanup(prob->ecos_prob, num_vars_keep);
     FREE(prob->tmp_bool_node_id);
@@ -289,12 +325,16 @@ void ECOS_BB_cleanup(ecos_bb_pwork* prob, idxint num_vars_keep){
     FREE(prob->z);
     FREE(prob->s);
     FREE(prob->info);
-    if (prob->default_settings){FREE(prob->stgs);}
+    if (prob->default_settings)
+    {
+        FREE(prob->stgs);
+    }
     FREE(prob);
 }
 
-settings_bb* get_default_ECOS_BB_settings(){
-    settings_bb* stgs = (settings_bb*) MALLOC( sizeof(settings_bb) );
+settings_bb *get_default_ECOS_BB_settings()
+{
+    settings_bb *stgs = (settings_bb *)MALLOC(sizeof(settings_bb));
     stgs->maxit = MI_MAXITER;
     stgs->verbose = 1;
     stgs->abs_tol_gap = MI_ABS_EPS;

--- a/ecos_bb/ecos_bb_preproc.c
+++ b/ecos_bb/ecos_bb_preproc.c
@@ -332,6 +332,10 @@ void ECOS_BB_cleanup(ecos_bb_pwork *prob, idxint num_vars_keep)
     FREE(prob->tmp_int_node_id);
     FREE(prob->tmp_branching_bool_node_id);
     FREE(prob->tmp_branching_int_node_id);
+    FREE(prob->Gpr_new);
+    FREE(prob->Gjc_new);
+    FREE(prob->Gir_new);
+    FREE(prob->h_new);
     FREE(prob->nodes);
     FREE(prob->bool_node_ids);
     FREE(prob->int_node_ids);

--- a/include/ecos_bb.h
+++ b/include/ecos_bb.h
@@ -112,7 +112,7 @@ extern "C"
 		idxint prev_split_idx;
 		pfloat prev_split_val;
 		pfloat prev_relaxation;
-		BOOL up_branch_node;
+		int up_branch_node;
 	} node;
 
 	/* Wrapper for mixed integer module */

--- a/include/ecos_bb.h
+++ b/include/ecos_bb.h
@@ -35,8 +35,6 @@
 /* Print verbosity */
 #define MI_PRINTLEVEL (1)
 
-#define LPA_FILE (1)
-
 /* ecos_bb configuration settings */
 #define MI_ABS_EPS (1E-6)
 #define MI_REL_EPS (1E-3)

--- a/include/ecos_bb.h
+++ b/include/ecos_bb.h
@@ -17,7 +17,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 /*
  * The branch and bound module is (c) Han Wang, Stanford University,
  * [hanwang2@stanford.edu]
@@ -67,127 +66,138 @@
 #define MAX_FLOAT_INT (8388608)
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-typedef struct settings_bb{
-	idxint maxit;               /* maximum number of iterations         */
-    idxint verbose;             /* verbosity bool for PRINTLEVEL < 3    */
-	pfloat abs_tol_gap;			/* termination criteria |U-L|    		*/
-	pfloat rel_tol_gap;			/* termination criteria for |U-L|/|L| < 3    */
-	pfloat integer_tol; 		/* integer rounding tolerance */
-} settings_bb;
+	typedef struct settings_bb
+	{
+		idxint maxit;		/* maximum number of iterations         */
+		idxint verbose;		/* verbosity bool for PRINTLEVEL < 3    */
+		pfloat abs_tol_gap; /* termination criteria |U-L|    		*/
+		pfloat rel_tol_gap; /* termination criteria for |U-L|/|L| < 3    */
+		pfloat integer_tol; /* integer rounding tolerance */
+	} settings_bb;
 
-typedef struct node {
-	char status;
-	pfloat L;
-	pfloat U;
-	idxint split_idx;
-	pfloat split_val;
-} node;
+	typedef struct node
+	{
+		char status;
+		pfloat L;
+		pfloat U;
+		idxint split_idx;
+		pfloat split_val;
+	} node;
 
-/* Wrapper for mixed integer module */
-typedef struct ecos_bb_pwork{
-	/* Mixed integer data */
-	idxint num_bool_vars;
-	idxint num_int_vars;
+	/* Wrapper for mixed integer module */
+	typedef struct ecos_bb_pwork
+	{
+		/* Mixed integer data */
+		idxint num_bool_vars;
+		idxint num_int_vars;
 
-	node* nodes;
-	char* bool_node_ids;
-	pfloat* int_node_ids;
+		node *nodes;
+		char *bool_node_ids;
+		pfloat *int_node_ids;
 
-	idxint* bool_vars_idx;
-	idxint* int_vars_idx;
+		idxint *bool_vars_idx;
+		idxint *int_vars_idx;
 
-	/* ECOS data */
-	pwork* ecos_prob;
+		/* ECOS data */
+		pwork *ecos_prob;
 
-	/* Modified pointers to ecos internals */
-	/* Use these to edit or reset the h variables */
-	spmat* A;
-	spmat* G;
-	pfloat* c;
-	pfloat* b;
-	pfloat* h;
+		/* Modified pointers to ecos internals */
+		/* Use these to edit or reset the h variables */
+		spmat *A;
+		spmat *G;
+		pfloat *c;
+		pfloat *b;
+		pfloat *h;
 
-	/* best iterate seen so far */
-    /* variables */
-    pfloat* x;  /* primal variables                    */
-    pfloat* y;  /* multipliers for equality constaints */
-    pfloat* z;  /* multipliers for conic inequalities  */
-    pfloat* s;  /* slacks for conic inequalities       */
-    pfloat kap; /* kappa (homogeneous embedding)       */
-	pfloat tau; /* tau (homogeneous embedding)         */
-    stats* info; /* info of best iterate               */
-	pfloat global_U;
-	pfloat global_L;
+		/* best iterate seen so far */
+		/* variables */
+		pfloat *x;   /* primal variables                    */
+		pfloat *y;   /* multipliers for equality constaints */
+		pfloat *z;   /* multipliers for conic inequalities  */
+		pfloat *s;   /* slacks for conic inequalities       */
+		pfloat kap;  /* kappa (homogeneous embedding)       */
+		pfloat tau;  /* tau (homogeneous embedding)         */
+		stats *info; /* info of best iterate               */
+		pfloat global_U;
+		pfloat global_L;
 
-	/* Tmp data */
-	char* tmp_bool_node_id;
-	pfloat* tmp_int_node_id;
-	idxint iter;
+		/* Tmp data */
+		char *tmp_bool_node_id;
+		pfloat *tmp_int_node_id;
+		idxint iter;
 
-	/* Stored pointers to prevent memory leaks */
-	pfloat* Gpr_new;
-	idxint* Gjc_new;
-	idxint* Gir_new;
-	pfloat* h_new;
+		/* Stored pointers to prevent memory leaks */
+		pfloat *Gpr_new;
+		idxint *Gjc_new;
+		idxint *Gir_new;
+		pfloat *h_new;
 
-	/* settings struct */
-	settings* ecos_stgs;
-	settings_bb* stgs;
-	idxint default_settings;
+		/* settings struct */
+		settings *ecos_stgs;
+		settings_bb *stgs;
+		idxint default_settings;
 
-} ecos_bb_pwork;
+	} ecos_bb_pwork;
 
-ecos_bb_pwork* ECOS_BB_setup(
-    idxint n, idxint m, idxint p,
-    idxint l, idxint ncones, idxint* q, idxint nex,
-    pfloat* Gpr, idxint* Gjc, idxint* Gir,
-    pfloat* Apr, idxint* Ajc, idxint* Air,
-    pfloat* c, pfloat* h, pfloat* b,
-    idxint num_bool_vars, idxint* bool_vars_idx,
-    idxint num_int_vars, idxint* int_vars_idx,
-    settings_bb* stgs);
+	ecos_bb_pwork *ECOS_BB_setup(
+		idxint n, idxint m, idxint p,
+		idxint l, idxint ncones, idxint *q, idxint nex,
+		pfloat *Gpr, idxint *Gjc, idxint *Gir,
+		pfloat *Apr, idxint *Ajc, idxint *Air,
+		pfloat *c, pfloat *h, pfloat *b,
+		idxint num_bool_vars, idxint *bool_vars_idx,
+		idxint num_int_vars, idxint *int_vars_idx,
+		settings_bb *stgs);
 
-idxint ECOS_BB_solve(ecos_bb_pwork* prob);
+	idxint ECOS_BB_solve(ecos_bb_pwork *prob);
 
-void ECOS_BB_cleanup(ecos_bb_pwork* prob, idxint num_vars_keep);
+	void ECOS_BB_cleanup(ecos_bb_pwork *prob, idxint num_vars_keep);
 
-void updateDataEntry_h(ecos_bb_pwork* w, idxint idx, pfloat value);
+	void updateDataEntry_h(ecos_bb_pwork *w, idxint idx, pfloat value);
 
-void updateDataEntry_c(ecos_bb_pwork* w, idxint idx, pfloat value);
+	void updateDataEntry_c(ecos_bb_pwork *w, idxint idx, pfloat value);
 
-settings_bb* get_default_ECOS_BB_settings();
+	settings_bb *get_default_ECOS_BB_settings();
 
-/* Calculate the offset into the node_id array */
-static char* get_bool_node_id(idxint idx, ecos_bb_pwork* prob){
-    return &prob->bool_node_ids[prob->num_bool_vars * idx];
-}
+	/* Calculate the offset into the node_id array */
+	static char *get_bool_node_id(idxint idx, ecos_bb_pwork *prob)
+	{
+		return &prob->bool_node_ids[prob->num_bool_vars * idx];
+	}
 
-static pfloat* get_int_node_id(idxint idx, ecos_bb_pwork* prob){
-    return &prob->int_node_ids[prob->num_int_vars * idx * 2];
-}
+	static pfloat *get_int_node_id(idxint idx, ecos_bb_pwork *prob)
+	{
+		return &prob->int_node_ids[prob->num_int_vars * idx * 2];
+	}
 
-static pfloat abs_2(pfloat number){
-	return number < 0.0 ? -number : number;
-}
+	static pfloat abs_2(pfloat number)
+	{
+		return number < 0.0 ? -number : number;
+	}
 
-static pfloat pfloat_round(pfloat number){
-    return (number >= 0) ? (int)(number + 0.5) : (int)(number - 0.5);
-}
+	static pfloat pfloat_round(pfloat number)
+	{
+		return (number >= 0) ? (int)(number + 0.5) : (int)(number - 0.5);
+	}
 
-static pfloat pfloat_ceil(pfloat number, pfloat integer_tol){
-	return (pfloat) (number < 0 ? (int) number : (int) (number+(1-integer_tol)) );
-}
+	static pfloat pfloat_ceil(pfloat number, pfloat integer_tol)
+	{
+		return (pfloat)(number < 0 ? (int)number : (int)(number + (1 - integer_tol)));
+	}
 
-static pfloat pfloat_floor(pfloat number, pfloat integer_tol){
-    return (pfloat) (number < 0 ? (int) (number-(1-integer_tol)) : (int) number);
-}
+	static pfloat pfloat_floor(pfloat number, pfloat integer_tol)
+	{
+		return (pfloat)(number < 0 ? (int)(number - (1 - integer_tol)) : (int)number);
+	}
 
-static idxint float_eqls(pfloat a, pfloat b, pfloat integer_tol){
-	return abs_2(a - b) < integer_tol;
-}
+	static idxint float_eqls(pfloat a, pfloat b, pfloat integer_tol)
+	{
+		return abs_2(a - b) < integer_tol;
+	}
 
 #ifdef __cplusplus
 }

--- a/include/ecos_bb.h
+++ b/include/ecos_bb.h
@@ -18,9 +18,12 @@
  */
 
 /*
- * The branch and bound module is (c) Han Wang, Stanford University,
- * [hanwang2@stanford.edu]
- */
+  * The branch and bound module is (c) Han Wang, Stanford University,
+  * [hanwang2@stanford.edu]
+  * 
+  * Extended with improved branching rules by Pascal Lüscher, student of FHNW
+  * [luescherpascal@gmail.com]
+  */
 
 #ifndef __ecos_bb_H__
 #define __ecos_bb_H__
@@ -31,6 +34,8 @@
 
 /* Print verbosity */
 #define MI_PRINTLEVEL (1)
+
+#define LPA_FILE (1)
 
 /* ecos_bb configuration settings */
 #define MI_ABS_EPS (1E-6)
@@ -70,6 +75,22 @@ extern "C"
 {
 #endif
 
+	enum BRANCHING_STRATEGY
+	{
+		BRANCHING_STRATEGY_MOST_INFEASIBLE = 0,
+		BRANCHING_STRATEGY_STRONG_BRANCHING = 1,
+		BRANCHING_STRATEGY_PSEUDOCOST_BRANCHING = 2,
+		BRANCHING_STRATEGY_RELIABILITY = 3,
+		BRANCHING_STRATEGY_RANDOM = 4
+	};
+
+	enum NODE_SELECTION_METHOD
+	{
+		BREADTH_FIRST = 0,
+		DIVE_LOWER_NODE = 1,
+		DIVE_UPPER_NODE = 2,
+	};
+
 	typedef struct settings_bb
 	{
 		idxint maxit;		/* maximum number of iterations         */
@@ -77,6 +98,9 @@ extern "C"
 		pfloat abs_tol_gap; /* termination criteria |U-L|    		*/
 		pfloat rel_tol_gap; /* termination criteria for |U-L|/|L| < 3    */
 		pfloat integer_tol; /* integer rounding tolerance */
+		enum BRANCHING_STRATEGY branching_strategy;
+		idxint reliable_eta; /* number of pseudocost values needed for costs to be reliable */
+		enum NODE_SELECTION_METHOD node_selection_method;
 	} settings_bb;
 
 	typedef struct node
@@ -84,8 +108,13 @@ extern "C"
 		char status;
 		pfloat L;
 		pfloat U;
+		pfloat relaxation;
 		idxint split_idx;
 		pfloat split_val;
+		idxint prev_split_idx;
+		pfloat prev_split_val;
+		pfloat prev_relaxation;
+		BOOL up_branch_node;
 	} node;
 
 	/* Wrapper for mixed integer module */
@@ -129,6 +158,17 @@ extern "C"
 		char *tmp_bool_node_id;
 		pfloat *tmp_int_node_id;
 		idxint iter;
+		idxint dive_node_id;
+
+		/* Tmp nodes used for strong branching */
+		char *tmp_branching_bool_node_id;
+		pfloat *tmp_branching_int_node_id;
+
+		/* Pseudocost branching values */
+		pfloat *pseudocost_bin_sum;
+		pfloat *pseudocost_int_sum;
+		idxint *pseudocost_bin_cnt;
+		idxint *pseudocost_int_cnt;
 
 		/* Stored pointers to prevent memory leaks */
 		pfloat *Gpr_new;


### PR DESCRIPTION
# [ECOS BB] Implemented superior branching rules and new node selection method

## Branching rules
In the current ecos version, the branching rule used is "most infeasible". It has been shown in several papers (for example Branching Rules revisited by T. Achterberg, T.Koch and A.Martin) that this rule is basicly as good as selecting a random node.

To check this statement I implemented the random branching strategy. My results are the same as in the paper: Most infeasible branching is only slightly better than random branching, both in solving problems in a time window and with an interation limit.

I implemented 3 new strategies: strong branching, pseudocost branching and reliability branching.
All these methods are superior to most-infeasible in some ways.

* Strong branching
    Strong branching the best method to get most out of your iterations. But in regards of time it is very slow and requires a lot of computations since it calculates all costs for up and down branching on every int/bool node.

* Pseudocost branching
    Pseudocost branching relies on previos decisions and branches based on these. It is superior to most infeasible branching both in time and how far you come with an iteration limit.

* Reliability branching
    Reliability branching combines strong and pseudocost branching. A variable is called unreliable if the pseudocost history for this variable is to small. In this case strong branching is used to determine the costs. This method brings an extra tuning parameter, in papers mostly called &eta;. I added it to `settings_bb->reliable_eta` and set the default value to `6`.
    I tested several &eta; with different datasets. between 4 and 8 seems to be a good value so I choose 6 as a default.

To visualize how much it improves the result I created this graph for the Problem PP08ACUTS (from miplib 2010 [download mps](http://miplib2010.zib.de/miplib3/miplib3/pp08aCUTS.mps.gz)) with the different strategies displayed. In the y-axis you see the Lower and upper-bound and in the x-axis the time in seconds:
![graph over time](https://i.imgur.com/drkftMQ.png)
since strong branching took so long i excluded it and the graph looks like this:
![graph without strong branching over time](https://i.imgur.com/cEdjNGw.png)
As you can see, the current implementation with most infeasible branching is just a little bit better than random branching. All other visible branching strategies are superior.

to show that strong branching is the best in regards of iteration limit, here the graph with iterations as x-axis, I limited the iterations of strong branching to 25'000 and to 50'000 for everything else. As you can see in the previous graphs, strong branching takes a long time.:
![graph over iterations](https://i.imgur.com/YItSlmV.png)

The branching strategy is chosen based on the `settings_bb->branching_strategy` parameter. I added an enum `BRANCHING_STRATEGY` for it.

	enum BRANCHING_STRATEGY
	{
		BRANCHING_STRATEGY_MOST_INFEASIBLE = 0,
		BRANCHING_STRATEGY_STRONG_BRANCHING = 1,
		BRANCHING_STRATEGY_PSEUDOCOST_BRANCHING = 2,
		BRANCHING_STRATEGY_RELIABILITY = 3,
		BRANCHING_STRATEGY_RANDOM = 4
	};

Since reliability branching is supperior to most infeasible in all cases and aspects, I added it as default branching strategy.

## Node selection methods
The current implementation uses a breath first approach, which is by definition the most efficient solution to prove the optimal solution. However most modern solvers use another techique called diving. For simplex based solvers this is a very efficient method for solving an ILP. 
With ECOS it is not as efficient but it is still a good method to find good integer solutions early on. In practice most of the time a customer is more interested in finding a good solution than improving the lower bound (and perhaps not finding a solution at all). 
With diving there are two possibiliteis, either dive on the left or on the right node. I implemented both methods. The node selection method can be set with the parameter `settings_bb->node_selection_method`. As before, I added an enum for easier understanding:

	enum NODE_SELECTION_METHOD
	{
		BREADTH_FIRST = 0,
		DIVE_LOWER_NODE = 1,
		DIVE_UPPER_NODE = 2,
	};

I also set `DIVE_LOWER_NODE` as default setting for the reasons stated above.

## Formatting & .gitignore
I autoformatted every file i touched and it matches now the style of ecos. I used vs-code so I added it to the .gitignore file

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/embotech/ecos/178)
<!-- Reviewable:end -->
