### PR TITLE
Add CMake Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ python/dist
 python/*.pyc
 
 .vscode/
+
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,112 +1,127 @@
 # CMake configuration for ECOS
 
 cmake_minimum_required(VERSION 3.5)
-project(ecos C)
+
+project(ecos
+        VERSION 2.2.7
+        LANGUAGES C)
 
 # Options
-option(USE_LONG "Whether to use Long or Int for index type." TRUE)
-option(ECOS_ENABLE_TESTING "Whether to compile tests." FALSE)
-
-# AMD
-add_library(amd SHARED)
-target_include_directories(amd SYSTEM PUBLIC
-    external/amd/include
-    external/SuiteSparse_config
-)
-target_sources(amd PRIVATE
-    external/amd/src/amd_1.c
-    external/amd/src/amd_2.c
-    external/amd/src/amd_aat.c
-    external/amd/src/amd_control.c
-    external/amd/src/amd_defaults.c
-    external/amd/src/amd_dump.c
-    external/amd/src/amd_global.c
-    external/amd/src/amd_info.c
-    external/amd/src/amd_order.c
-    external/amd/src/amd_post_tree.c
-    external/amd/src/amd_postorder.c
-    external/amd/src/amd_preprocess.c
-    external/amd/src/amd_valid.c
-)
-
-# LDL
-add_library(ldl SHARED)
-target_include_directories(ldl SYSTEM PUBLIC
-    include
-    external/ldl/include
-    external/SuiteSparse_config
-)
-target_sources(ldl PRIVATE
-    external/ldl/src/ldl.c
-)
-
-# ECOS
-add_library(ecos SHARED)
-target_include_directories(ecos SYSTEM PUBLIC
-    include
-    external/SuiteSparse_config
-)
-target_sources(ecos PRIVATE
-    src/cone.c
-    src/ctrlc.c
-    src/ecos.c
-    src/equil.c
-    src/expcone.c
-    src/kkt.c
-    src/preproc.c
-    src/spla.c
-    src/splamm.c
-    src/timer.c
-    src/wright_omega.c
-
-    ecos_bb/ecos_bb.c
-    ecos_bb/ecos_bb_preproc.c
-)
+option(USE_LONG "Whether to use Long or Int for index type." ON)
 
 # Set compiler flags
-set(DEBUG_OPTIONS -Wall -Wextra)
-set(RELEASE_OPTIONS -O2)
-target_compile_options(ecos PUBLIC "$<$<CONFIG:DEBUG>:${DEBUG_OPTIONS}>")
-target_compile_options(ecos PUBLIC "$<$<CONFIG:RELEASE>:${RELEASE_OPTIONS}>")
+set(DEBUG_OPTIONS -O0 -Wall -Wextra)
+set(RELEASE_OPTIONS -O3)
 
-# Set compiler definitions
-target_compile_definitions(ecos PUBLIC fPIC CTRLC=1)
+# Add the ECOS headers
+set(ecos_headers
+    "${CMAKE_CURRENT_SOURCE_DIR}/external/SuiteSparse_config/SuiteSparse_config.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/cone.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/ctrlc.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/data.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/ecos.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/ecos_bb.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/equil.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/expcone.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/glblopts.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/kkt.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/spla.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/splamm.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/timer.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/wright_omega.h"
+)
+
+set(ecos_sources
+    # AMD
+    "${CMAKE_CURRENT_SOURCE_DIR}/external/amd/src/amd_1.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/external/amd/src/amd_2.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/external/amd/src/amd_aat.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/external/amd/src/amd_control.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/external/amd/src/amd_defaults.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/external/amd/src/amd_dump.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/external/amd/src/amd_global.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/external/amd/src/amd_info.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/external/amd/src/amd_order.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/external/amd/src/amd_post_tree.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/external/amd/src/amd_postorder.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/external/amd/src/amd_preprocess.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/external/amd/src/amd_valid.c"
+
+    # LDL
+    "${CMAKE_CURRENT_SOURCE_DIR}/external/ldl/src/ldl.c"
+
+    # ECOS
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/cone.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/ctrlc.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/ecos.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/equil.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/expcone.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/kkt.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/preproc.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/spla.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/splamm.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/timer.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/wright_omega.c"
+
+    # ECOS BB
+    "${CMAKE_CURRENT_SOURCE_DIR}/ecos_bb/ecos_bb.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/ecos_bb/ecos_bb_preproc.c"
+)
+
+# ECOS library
+add_library(ecos SHARED ${ecos_headers} ${ecos_sources})
+
+# Set compiler options and definitions
+target_compile_options(ecos PRIVATE "$<$<CONFIG:DEBUG>:${DEBUG_OPTIONS}>")
+target_compile_options(ecos PRIVATE "$<$<CONFIG:RELEASE>:${RELEASE_OPTIONS}>")
+target_compile_definitions(ecos PUBLIC CTRLC=1)
 if(USE_LONG)
-    target_compile_definitions(ldl PUBLIC LDL_LONG DLONG)
-    target_compile_definitions(amd PUBLIC LDL_LONG DLONG)
+    target_compile_definitions(ecos PUBLIC LDL_LONG DLONG)
 endif()
 
-target_link_libraries(ecos amd ldl m)
+# Link math library
+target_link_libraries(ecos PRIVATE m)
 
-# Tests
-if(ECOS_ENABLE_TESTING)
-    add_library(ecos_test)
+target_include_directories(ecos
+    PUBLIC 
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/external/amd/include>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/external/ldl/include>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/external/SuiteSparse_config>"
+    "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}/ecos>"
+)
 
-    target_include_directories(ecos_test SYSTEM PUBLIC
-        test
-        test/generated
-    )
+# Installation
+include(GNUInstallDirs)
 
-    target_sources(ecos_test PRIVATE
-        test/generated/inv_pos/inv_pos.c
-        test/generated/norm/norm.c
-        test/generated/quad_over_lin/quad_over_lin.c
-        test/generated/sq_norm/sq_norm.c
-        test/generated/sum_sq/sum_sq.c
-        test/generated/qcml_utils.c
-    )
+install(TARGETS ecos
+        EXPORT  ${PROJECT_NAME}
+        ARCHIVE       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        RUNTIME       DESTINATION "${CMAKE_INSTALL_BINDIR}"
+)
 
-    target_link_libraries(ecos_test ecos)
+install(FILES ${ecos_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/ecos")
 
-    add_executable(runecos src/runecos.c)
-    target_link_libraries(runecos ecos_test)
+# Create CMake packages for the build directory
+include(CMakePackageConfigHelpers)
 
-    add_executable(runecos_exp src/runecos_exp.c)
-    target_link_libraries(runecos_exp ecos_test)
+export(EXPORT ${PROJECT_NAME}
+  FILE "${CMAKE_CURRENT_BINARY_DIR}/ecos-targets.cmake"
+  NAMESPACE ecos::
+)
 
-    add_executable(ecostester test/ecostester.c)
-    target_link_libraries(ecostester ecos_test)
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/ecos-config.cmake "include(\"\${CMAKE_CURRENT_LIST_DIR}/ecos-targets.cmake\")\n")
 
-    add_executable(bb_test test/bb_test.c)
-    target_link_libraries(bb_test ecos_test)
-endif()
+# Create CMake packages for the install directory
+set(ConfigPackageLocation ${CMAKE_INSTALL_LIBDIR}/cmake/ecos)
+
+install(EXPORT ${PROJECT_NAME}
+        FILE ecos-targets.cmake
+        NAMESPACE ecos::
+        DESTINATION ${ConfigPackageLocation}
+)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ecos-config.cmake
+        DESTINATION ${ConfigPackageLocation}
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,112 @@
+# CMake configuration for ECOS
+
+cmake_minimum_required(VERSION 3.5)
+project(ecos C)
+
+# Options
+option(USE_LONG "Whether to use Long or Int for index type." TRUE)
+option(ECOS_ENABLE_TESTING "Whether to compile tests." FALSE)
+
+# AMD
+add_library(amd SHARED)
+target_include_directories(amd SYSTEM PUBLIC
+    external/amd/include
+    external/SuiteSparse_config
+)
+target_sources(amd PRIVATE
+    external/amd/src/amd_1.c
+    external/amd/src/amd_2.c
+    external/amd/src/amd_aat.c
+    external/amd/src/amd_control.c
+    external/amd/src/amd_defaults.c
+    external/amd/src/amd_dump.c
+    external/amd/src/amd_global.c
+    external/amd/src/amd_info.c
+    external/amd/src/amd_order.c
+    external/amd/src/amd_post_tree.c
+    external/amd/src/amd_postorder.c
+    external/amd/src/amd_preprocess.c
+    external/amd/src/amd_valid.c
+)
+
+# LDL
+add_library(ldl SHARED)
+target_include_directories(ldl SYSTEM PUBLIC
+    include
+    external/ldl/include
+    external/SuiteSparse_config
+)
+target_sources(ldl PRIVATE
+    external/ldl/src/ldl.c
+)
+
+# ECOS
+add_library(ecos SHARED)
+target_include_directories(ecos SYSTEM PUBLIC
+    include
+    external/SuiteSparse_config
+)
+target_sources(ecos PRIVATE
+    src/cone.c
+    src/ctrlc.c
+    src/ecos.c
+    src/equil.c
+    src/expcone.c
+    src/kkt.c
+    src/preproc.c
+    src/spla.c
+    src/splamm.c
+    src/timer.c
+    src/wright_omega.c
+
+    ecos_bb/ecos_bb.c
+    ecos_bb/ecos_bb_preproc.c
+)
+
+# Set compiler flags
+set(DEBUG_OPTIONS -Wall -Wextra)
+set(RELEASE_OPTIONS -O2)
+target_compile_options(ecos PUBLIC "$<$<CONFIG:DEBUG>:${DEBUG_OPTIONS}>")
+target_compile_options(ecos PUBLIC "$<$<CONFIG:RELEASE>:${RELEASE_OPTIONS}>")
+
+# Set compiler definitions
+target_compile_definitions(ecos PUBLIC fPIC CTRLC=1)
+if(USE_LONG)
+    target_compile_definitions(ldl PUBLIC LDL_LONG DLONG)
+    target_compile_definitions(amd PUBLIC LDL_LONG DLONG)
+endif()
+
+target_link_libraries(ecos amd ldl m)
+
+# Tests
+if(ECOS_ENABLE_TESTING)
+    add_library(ecos_test)
+
+    target_include_directories(ecos_test SYSTEM PUBLIC
+        test
+        test/generated
+    )
+
+    target_sources(ecos_test PRIVATE
+        test/generated/inv_pos/inv_pos.c
+        test/generated/norm/norm.c
+        test/generated/quad_over_lin/quad_over_lin.c
+        test/generated/sq_norm/sq_norm.c
+        test/generated/sum_sq/sum_sq.c
+        test/generated/qcml_utils.c
+    )
+
+    target_link_libraries(ecos_test ecos)
+
+    add_executable(runecos src/runecos.c)
+    target_link_libraries(runecos ecos_test)
+
+    add_executable(runecos_exp src/runecos_exp.c)
+    target_link_libraries(runecos_exp ecos_test)
+
+    add_executable(ecostester test/ecostester.c)
+    target_link_libraries(ecostester ecos_test)
+
+    add_executable(bb_test test/bb_test.c)
+    target_link_libraries(bb_test ecos_test)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,16 @@ project(ecos
 option(USE_LONG "Whether to use Long or Int for index type." ON)
 
 # Set compiler flags
-set(DEBUG_OPTIONS -O0 -Wall -Wextra)
-set(RELEASE_OPTIONS -O3)
+set(DEBUG_OPTIONS "")
+set(RELEASE_OPTIONS "")
+
+if(MSVC)
+    list(APPEND DEBUG_OPTIONS "/Od" "/Wall")
+    list(APPEND RELEASE_OPTIONS "/O2")
+else()
+    list(APPEND DEBUG_OPTIONS "-O0" "-Wall" "-Wextra")
+    list(APPEND RELEASE_OPTIONS "-O3")
+endif()
 
 # Add the ECOS headers
 set(ecos_headers
@@ -80,7 +88,9 @@ if(USE_LONG)
 endif()
 
 # Link math library
-target_link_libraries(ecos PRIVATE m)
+if(NOT MSVC)
+    target_link_libraries(ecos PRIVATE m)
+endif()
 
 target_include_directories(ecos
     PUBLIC 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.5)
 
 project(ecos
-        VERSION 2.2.7
+        VERSION 2.0.7
         LANGUAGES C)
 
 # Options


### PR DESCRIPTION
This will make it easier to use ECOS in CMake projects e.g. in the [Epigraph](https://github.com/EmbersArc/Epigraph) library. The current process is not very elegant and difficult to use cross-platform.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/embotech/ecos/188)
<!-- Reviewable:end -->
