### PR TITLE
Move GNUInstallDirs include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,8 @@ if(NOT MSVC)
     target_link_libraries(ecos PRIVATE m)
 endif()
 
+include(GNUInstallDirs)
+
 target_include_directories(ecos
     PUBLIC 
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
@@ -102,8 +104,6 @@ target_include_directories(ecos
 )
 
 # Installation
-include(GNUInstallDirs)
-
 install(TARGETS ecos
         EXPORT  ${PROJECT_NAME}
         ARCHIVE       DESTINATION "${CMAKE_INSTALL_LIBDIR}"


### PR DESCRIPTION
I noticed an issue with the CMake installation: The line to import the include directory was in the wrong place which lead to the important preprocessor definitions `LDL_LONG` and `DLONG` not being included correctly . I tested this change on Linux.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/embotech/ecos/189)
<!-- Reviewable:end -->
