### PR TITLE
check if constraints are not NULL before unsetting equilibration

### DIFF
--- a/src/ecos.c
+++ b/src/ecos.c
@@ -1655,11 +1655,11 @@ void ECOS_updateData(pwork *w, pfloat *Gpr, pfloat *Apr,
     /* Only unequilibrate the old data if the new data is in a different location in memory. */
     /* This is required for backward compatibility since existing code might need this step. */
     if (
-        ((Gpr + w->G->nnz < w->G->pr) || (w->G->pr + w->G->nnz < Gpr)) &&
-        ((Apr + w->A->nnz < w->A->pr) || (w->A->pr + w->A->nnz < Apr)) &&
+        (!w->G || ((Gpr + w->G->nnz < w->G->pr) || (w->G->pr + w->G->nnz < Gpr))) &&
+        (!w->A || ((Apr + w->A->nnz < w->A->pr) || (w->A->pr + w->A->nnz < Apr))) &&
         ((c + w->n < w->c) || (w->c + w->n < c)) &&
-        ((h + w->m < w->h) || (w->h + w->m < h)) &&
-        ((b + w->p < w->b) || (w->b + w->p < b))
+        (!w->h || ((h + w->m < w->h) || (w->h + w->m < h))) &&
+        (!w->b || ((b + w->p < w->b) || (w->b + w->p < b)))
     ){
     unset_equilibration(w);
     }

--- a/src/equil.c
+++ b/src/equil.c
@@ -371,9 +371,9 @@ void unset_equilibration(pwork *w)
     idxint i;
     /* idxint num_cols = w->A ? w->A->n : w->G->n; */
     idxint num_A_rows = w->A ? w->A->m : 0;
-    idxint num_G_rows = w->G->m;
+    idxint num_G_rows = w->G ? w->G->m : 0;
 
-    if(w->A)
+    if(num_A_rows > 0)
         restore(w->Aequil, w->xequil, w->A);
     if(num_G_rows > 0)
         restore(w->Gequil, w->xequil, w->G);


### PR DESCRIPTION
I encountered a segfault while running ECOS_updateData without any equality constraint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/embotech/ecos/212)
<!-- Reviewable:end -->
